### PR TITLE
Remove Validate call

### DIFF
--- a/ibmpisession/ibmpowersession.go
+++ b/ibmpisession/ibmpowersession.go
@@ -138,9 +138,6 @@ func fetchAuthorizationData(s *IBMPISession) (string, error) {
 		req := &http.Request{
 			Header: make(http.Header),
 		}
-		if err := s.Authenticator.Validate(); err != nil {
-			return "", err
-		}
 		if err := s.Authenticator.Authenticate(req); err != nil {
 			return "", err
 		}


### PR DESCRIPTION
This Validate() call is not necessary and also there are issues with calling Validate() post-authentication refer https://github.com/IBM/go-sdk-core/issues/150