### PR TITLE
Fix the import path in the test files

### DIFF
--- a/clients/instance/ibm-pi-cloud_connection_integration_test.go
+++ b/clients/instance/ibm-pi-cloud_connection_integration_test.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"testing"
 
-	utl "internal/testutils"
+	utl "github.com/IBM-Cloud/power-go-client/internal/testutils"
 
 	client "github.com/IBM-Cloud/power-go-client/clients/instance"
 	"github.com/IBM-Cloud/power-go-client/power/models"

--- a/clients/instance/ibm-pi-dhcp_integration_test.go
+++ b/clients/instance/ibm-pi-dhcp_integration_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 	"time"
 
-	utl "internal/testutils"
+	utl "github.com/IBM-Cloud/power-go-client/internal/testutils"
 
 	client "github.com/IBM-Cloud/power-go-client/clients/instance"
 	"github.com/IBM-Cloud/power-go-client/power/models"

--- a/clients/instance/ibm-pi-image_integration_test.go
+++ b/clients/instance/ibm-pi-image_integration_test.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"testing"
 
-	utl "internal/testutils"
+	utl "github.com/IBM-Cloud/power-go-client/internal/testutils"
 
 	client "github.com/IBM-Cloud/power-go-client/clients/instance"
 	"github.com/stretchr/testify/require"

--- a/clients/instance/ibm-pi-instance_integration_test.go
+++ b/clients/instance/ibm-pi-instance_integration_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 	"time"
 
-	utl "internal/testutils"
+	utl "github.com/IBM-Cloud/power-go-client/internal/testutils"
 
 	client "github.com/IBM-Cloud/power-go-client/clients/instance"
 	"github.com/IBM-Cloud/power-go-client/power/models"

--- a/clients/instance/ibm-pi-key_integration_test.go
+++ b/clients/instance/ibm-pi-key_integration_test.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"testing"
 
-	utl "internal/testutils"
+	utl "github.com/IBM-Cloud/power-go-client/internal/testutils"
 
 	client "github.com/IBM-Cloud/power-go-client/clients/instance"
 	"github.com/IBM-Cloud/power-go-client/power/models"

--- a/clients/instance/ibm-pi-network_integration_test.go
+++ b/clients/instance/ibm-pi-network_integration_test.go
@@ -7,7 +7,7 @@ import (
 	"strconv"
 	"testing"
 
-	utl "internal/testutils"
+	utl "github.com/IBM-Cloud/power-go-client/internal/testutils"
 
 	"github.com/apparentlymart/go-cidr/cidr"
 	"github.com/stretchr/testify/require"

--- a/clients/instance/ibm-pi-snapshot_integration_test.go
+++ b/clients/instance/ibm-pi-snapshot_integration_test.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"testing"
 
-	utl "internal/testutils"
+	utl "github.com/IBM-Cloud/power-go-client/internal/testutils"
 
 	client "github.com/IBM-Cloud/power-go-client/clients/instance"
 	"github.com/IBM-Cloud/power-go-client/power/models"

--- a/clients/instance/ibm-pi-storage_capacity_integration_test.go
+++ b/clients/instance/ibm-pi-storage_capacity_integration_test.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"testing"
 
-	utl "internal/testutils"
+	utl "github.com/IBM-Cloud/power-go-client/internal/testutils"
 
 	client "github.com/IBM-Cloud/power-go-client/clients/instance"
 	"github.com/stretchr/testify/require"

--- a/clients/instance/ibm-pi-volume_integration_test.go
+++ b/clients/instance/ibm-pi-volume_integration_test.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"testing"
 
-	utl "internal/testutils"
+	utl "github.com/IBM-Cloud/power-go-client/internal/testutils"
 
 	client "github.com/IBM-Cloud/power-go-client/clients/instance"
 	"github.com/IBM-Cloud/power-go-client/power/models"

--- a/clients/instance/ibm-pi-vpn_integration_test.go
+++ b/clients/instance/ibm-pi-vpn_integration_test.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"testing"
 
-	utl "internal/testutils"
+	utl "github.com/IBM-Cloud/power-go-client/internal/testutils"
 
 	client "github.com/IBM-Cloud/power-go-client/clients/instance"
 	"github.com/IBM-Cloud/power-go-client/power/models"

--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/go-openapi/strfmt v0.21.2
 	github.com/go-openapi/swag v0.21.1
 	github.com/go-openapi/validate v0.20.3
+	github.com/stretchr/testify v1.7.0
 )
 
 require (
@@ -41,10 +42,3 @@ require (
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b // indirect
 )
-
-require (
-	github.com/stretchr/testify v1.7.0
-	internal/testutils v1.0.0
-)
-
-replace internal/testutils => ./internal/testutils

--- a/internal/testutils/go.mod
+++ b/internal/testutils/go.mod
@@ -1,3 +1,0 @@
-module testutils
-
-go 1.17


### PR DESCRIPTION
There we issues while using the latest package with `go mod tidy`

```
sigs.k8s.io/ibm-powervs-block-csi-driver/pkg/cloud imports
	github.com/IBM-Cloud/power-go-client/clients/instance tested by
	github.com/IBM-Cloud/power-go-client/clients/instance.test imports
	internal/testutils: malformed module path "internal/testutils": missing dot in first path element
```