### PR TITLE
Cleaned up VPN

### DIFF
--- a/clients/instance/ibm-pi-vpn.go
+++ b/clients/instance/ibm-pi-vpn.go
@@ -5,77 +5,109 @@ import (
 	"fmt"
 
 	"github.com/IBM-Cloud/power-go-client/errors"
-	"github.com/IBM-Cloud/power-go-client/helpers"
-
 	"github.com/IBM-Cloud/power-go-client/ibmpisession"
-	"github.com/IBM-Cloud/power-go-client/power/client/p_cloud_v_p_n_connections"
+	params "github.com/IBM-Cloud/power-go-client/power/client/p_cloud_v_p_n_connections"
 	"github.com/IBM-Cloud/power-go-client/power/models"
+	"github.com/go-openapi/runtime"
 )
 
 // IBMPIVpnConnectionClient ...
 type IBMPIVpnConnectionClient struct {
-	IBMPIClient
+	auth            runtime.ClientAuthInfoWriter
+	cloudInstanceID string
+	context         context.Context
+	request         params.ClientService
 }
 
 // NewIBMPIVpnConnectionClient ...
 func NewIBMPIVpnConnectionClient(ctx context.Context, sess *ibmpisession.IBMPISession, cloudInstanceID string) *IBMPIVpnConnectionClient {
 	return &IBMPIVpnConnectionClient{
-		*NewIBMPIClient(ctx, sess, cloudInstanceID),
+		auth:            sess.AuthInfo(cloudInstanceID),
+		cloudInstanceID: cloudInstanceID,
+		context:         ctx,
+		request:         sess.Power.PCloudvpnConnections,
 	}
 }
 
-// Get information about a VPN connection
-func (f *IBMPIVpnConnectionClient) Get(id string) (*models.VPNConnection, error) {
-	params := p_cloud_v_p_n_connections.NewPcloudVpnconnectionsGetParams().
-		WithContext(f.ctx).WithTimeout(helpers.PIGetTimeOut).
-		WithCloudInstanceID(f.cloudInstanceID).WithVpnConnectionID(id)
-	resp, err := f.session.Power.PCloudvpnConnections.PcloudVpnconnectionsGet(params, f.session.AuthInfo(f.cloudInstanceID))
+// Get a VPN Connection
+func (f *IBMPIVpnConnectionClient) Get(vpnID string) (*models.VPNConnection, error) {
+
+	// Create params and send request
+	params := &params.PcloudVpnconnectionsGetParams{
+		CloudInstanceID: f.cloudInstanceID,
+		Context:         f.context,
+		VpnConnectionID: vpnID,
+	}
+	//params.SetTimeout(helpers.PIGetTimeOut)
+	resp, err := f.request.PcloudVpnconnectionsGet(params, f.auth)
+
+	// Handle errors
 	if err != nil {
-		return nil, fmt.Errorf(errors.GetVPNConnectionOperationFailed, id, err)
+		return nil, fmt.Errorf(errors.GetVPNConnectionOperationFailed, vpnID, err)
 	}
 	if resp == nil || resp.Payload == nil {
-		return nil, fmt.Errorf("failed to Get VPN Connection %s", id)
+		return nil, fmt.Errorf("failed to Get VPN Connection %s", vpnID)
 	}
 	return resp.Payload, nil
 }
 
-// Create a VPN connection
-func (f *IBMPIVpnConnectionClient) Create(body *models.VPNConnectionCreate) (*models.VPNConnectionCreateResponse, error) {
-	params := p_cloud_v_p_n_connections.NewPcloudVpnconnectionsPostParams().
-		WithContext(f.ctx).WithTimeout(helpers.PICreateTimeOut).
-		WithCloudInstanceID(f.cloudInstanceID).WithBody(body)
-	postaccepted, err := f.session.Power.PCloudvpnConnections.PcloudVpnconnectionsPost(params, f.session.AuthInfo(f.cloudInstanceID))
+// Create a VPN Connection
+func (f *IBMPIVpnConnectionClient) Create(createBody *models.VPNConnectionCreate) (*models.VPNConnectionCreateResponse, error) {
+
+	// Create params and send request
+	params := &params.PcloudVpnconnectionsPostParams{
+		Body:            createBody,
+		CloudInstanceID: f.cloudInstanceID,
+		Context:         f.context,
+	}
+	//params.SetTimeout(helpers.PICreateTimeOut)
+	resp, err := f.request.PcloudVpnconnectionsPost(params, f.auth)
+
+	// Handle errors
 	if err != nil {
 		return nil, fmt.Errorf(errors.CreateVPNConnectionOperationFailed, f.cloudInstanceID, err)
 	}
-	if postaccepted != nil && postaccepted.Payload != nil {
-		return postaccepted.Payload, nil
+	if resp != nil && resp.Payload != nil {
+		return resp.Payload, nil
 	}
 	return nil, fmt.Errorf("failed to Create VPN Connection")
 }
 
-// Update a VPN connection
-func (f *IBMPIVpnConnectionClient) Update(id string, body *models.VPNConnectionUpdate) (*models.VPNConnection, error) {
-	params := p_cloud_v_p_n_connections.NewPcloudVpnconnectionsPutParams().
-		WithContext(f.ctx).WithTimeout(helpers.PIUpdateTimeOut).
-		WithCloudInstanceID(f.cloudInstanceID).WithVpnConnectionID(id).
-		WithBody(body)
-	putok, err := f.session.Power.PCloudvpnConnections.PcloudVpnconnectionsPut(params, f.session.AuthInfo(f.cloudInstanceID))
+// Update a VPN Connection
+func (f *IBMPIVpnConnectionClient) Update(vpnID string, updateBody *models.VPNConnectionUpdate) (*models.VPNConnection, error) {
+
+	// Create params and send request
+	params := &params.PcloudVpnconnectionsPutParams{
+		Body:            updateBody,
+		CloudInstanceID: f.cloudInstanceID,
+		Context:         f.context,
+		VpnConnectionID: vpnID,
+	}
+	//params.SetTimeout(helpers.PIUpdateTimeOut)
+	resp, err := f.request.PcloudVpnconnectionsPut(params, f.auth)
+
+	// Handle errors
 	if err != nil {
-		return nil, fmt.Errorf(errors.UpdateVPNConnectionOperationFailed, id, err)
+		return nil, fmt.Errorf(errors.UpdateVPNConnectionOperationFailed, vpnID, err)
 	}
-	if putok != nil && putok.Payload != nil {
-		return putok.Payload, nil
+	if resp != nil && resp.Payload != nil {
+		return resp.Payload, nil
 	}
-	return nil, fmt.Errorf("failed to Update VPN Connection %s", id)
+	return nil, fmt.Errorf("failed to Update VPN Connection %s", vpnID)
 }
 
-// Get all VPN connections
+// Get All VPN Connections
 func (f *IBMPIVpnConnectionClient) GetAll() (*models.VPNConnections, error) {
-	params := p_cloud_v_p_n_connections.NewPcloudVpnconnectionsGetallParams().
-		WithContext(f.ctx).WithTimeout(helpers.PIGetTimeOut).
-		WithCloudInstanceID(f.cloudInstanceID)
-	resp, err := f.session.Power.PCloudvpnConnections.PcloudVpnconnectionsGetall(params, f.session.AuthInfo(f.cloudInstanceID))
+
+	// Create params and send request
+	params := &params.PcloudVpnconnectionsGetallParams{
+		CloudInstanceID: f.cloudInstanceID,
+		Context:         f.context,
+	}
+	//params.SetTimeout(helpers.PIGetTimeOut)
+	resp, err := f.request.PcloudVpnconnectionsGetall(params, f.auth)
+
+	// Handle errors
 	if err != nil {
 		return nil, fmt.Errorf("failed to Get all VPN Connections: %w", err)
 	}
@@ -85,45 +117,21 @@ func (f *IBMPIVpnConnectionClient) GetAll() (*models.VPNConnections, error) {
 	return resp.Payload, nil
 }
 
-// Delete a VPN connection
-func (f *IBMPIVpnConnectionClient) Delete(id string) (*models.JobReference, error) {
-	params := p_cloud_v_p_n_connections.NewPcloudVpnconnectionsDeleteParams().
-		WithContext(f.ctx).WithTimeout(helpers.PIDeleteTimeOut).
-		WithCloudInstanceID(f.cloudInstanceID).WithVpnConnectionID(id)
-	delaccepted, err := f.session.Power.PCloudvpnConnections.PcloudVpnconnectionsDelete(params, f.session.AuthInfo(f.cloudInstanceID))
-	if err != nil {
-		return nil, fmt.Errorf(errors.DeleteVPNConnectionOperationFailed, id, err)
-	}
-	if delaccepted != nil && delaccepted.Payload != nil {
-		return delaccepted.Payload, nil
-	}
-	return nil, nil
-}
+// Delete a VPN Connection
+func (f *IBMPIVpnConnectionClient) Delete(vpnID string) (*models.JobReference, error) {
 
-// Network get
-func (f *IBMPIVpnConnectionClient) GetNetwork(id string) (*models.NetworkIDs, error) {
-	params := p_cloud_v_p_n_connections.NewPcloudVpnconnectionsNetworksGetParams().
-		WithContext(f.ctx).WithTimeout(helpers.PIGetTimeOut).
-		WithCloudInstanceID(f.cloudInstanceID).WithVpnConnectionID(id)
-	resp, err := f.session.Power.PCloudvpnConnections.PcloudVpnconnectionsNetworksGet(params, f.session.AuthInfo(f.cloudInstanceID))
-	if err != nil {
-		return nil, fmt.Errorf("failed to Get Networks for VPN Connection %s: %w", id, err)
+	// Create params and send request
+	params := &params.PcloudVpnconnectionsDeleteParams{
+		CloudInstanceID: f.cloudInstanceID,
+		Context:         f.context,
+		VpnConnectionID: vpnID,
 	}
-	if resp == nil || resp.Payload == nil {
-		return nil, fmt.Errorf("failed to Get Networks for VPN Connection %s", id)
-	}
-	return resp.Payload, nil
-}
+	//params.SetTimeout(helpers.PIDeleteTimeOut)
+	resp, err := f.request.PcloudVpnconnectionsDelete(params, f.auth)
 
-// Network attach
-func (f *IBMPIVpnConnectionClient) AddNetwork(id, networkID string) (*models.JobReference, error) {
-	params := p_cloud_v_p_n_connections.NewPcloudVpnconnectionsNetworksPutParams().
-		WithContext(f.ctx).WithTimeout(helpers.PIUpdateTimeOut).
-		WithCloudInstanceID(f.cloudInstanceID).WithVpnConnectionID(id).
-		WithBody(&models.NetworkID{NetworkID: &networkID})
-	resp, err := f.session.Power.PCloudvpnConnections.PcloudVpnconnectionsNetworksPut(params, f.session.AuthInfo(f.cloudInstanceID))
+	// Handle errors
 	if err != nil {
-		return nil, fmt.Errorf("failed to Add Network %s to VPN Connection %s: %w", networkID, id, err)
+		return nil, fmt.Errorf(errors.DeleteVPNConnectionOperationFailed, vpnID, err)
 	}
 	if resp != nil && resp.Payload != nil {
 		return resp.Payload, nil
@@ -131,15 +139,44 @@ func (f *IBMPIVpnConnectionClient) AddNetwork(id, networkID string) (*models.Job
 	return nil, nil
 }
 
-// Network detach
-func (f *IBMPIVpnConnectionClient) DeleteNetwork(id, networkID string) (*models.JobReference, error) {
-	params := p_cloud_v_p_n_connections.NewPcloudVpnconnectionsNetworksDeleteParams().
-		WithContext(f.ctx).WithTimeout(helpers.PIDeleteTimeOut).
-		WithCloudInstanceID(f.cloudInstanceID).WithVpnConnectionID(id).
-		WithBody(&models.NetworkID{NetworkID: &networkID})
-	resp, err := f.session.Power.PCloudvpnConnections.PcloudVpnconnectionsNetworksDelete(params, f.session.AuthInfo(f.cloudInstanceID))
+// Get a VPN Connection Network
+func (f *IBMPIVpnConnectionClient) GetNetwork(vpnID string) (*models.NetworkIDs, error) {
+
+	// Create params and send request
+	params := &params.PcloudVpnconnectionsNetworksGetParams{
+		CloudInstanceID: f.cloudInstanceID,
+		Context:         f.context,
+		VpnConnectionID: vpnID,
+	}
+	//params.SetTimeout(helpers.PIGetTimeOut)
+	resp, err := f.request.PcloudVpnconnectionsNetworksGet(params, f.auth)
+
+	// Handle errors
 	if err != nil {
-		return nil, fmt.Errorf("failed to Delete Network %s from VPN Connection %s: %w", networkID, id, err)
+		return nil, fmt.Errorf("failed to Get Networks for VPN Connection %s: %w", vpnID, err)
+	}
+	if resp == nil || resp.Payload == nil {
+		return nil, fmt.Errorf("failed to Get Networks for VPN Connection %s", vpnID)
+	}
+	return resp.Payload, nil
+}
+
+// Add a Network to a VPN Connection
+func (f *IBMPIVpnConnectionClient) AddNetwork(vpnID, networkID string) (*models.JobReference, error) {
+
+	// Create params and send request
+	params := &params.PcloudVpnconnectionsNetworksPutParams{
+		Body:            &models.NetworkID{NetworkID: &networkID},
+		CloudInstanceID: f.cloudInstanceID,
+		Context:         f.context,
+		VpnConnectionID: vpnID,
+	}
+	//params.SetTimeout(helpers.PIUpdateTimeOut)
+	resp, err := f.request.PcloudVpnconnectionsNetworksPut(params, f.auth)
+
+	// Handle errors
+	if err != nil {
+		return nil, fmt.Errorf("failed to Add Network %s to VPN Connection %s: %w", networkID, vpnID, err)
 	}
 	if resp != nil && resp.Payload != nil {
 		return resp.Payload, nil
@@ -147,49 +184,93 @@ func (f *IBMPIVpnConnectionClient) DeleteNetwork(id, networkID string) (*models.
 	return nil, nil
 }
 
-// Subnet get
-func (f *IBMPIVpnConnectionClient) GetSubnet(id string) (*models.PeerSubnets, error) {
-	params := p_cloud_v_p_n_connections.NewPcloudVpnconnectionsPeersubnetsGetParams().
-		WithContext(f.ctx).WithTimeout(helpers.PIGetTimeOut).
-		WithCloudInstanceID(f.cloudInstanceID).WithVpnConnectionID(id)
-	resp, err := f.session.Power.PCloudvpnConnections.PcloudVpnconnectionsPeersubnetsGet(params, f.session.AuthInfo(f.cloudInstanceID))
+// Detach a Network from a VPN Connection
+func (f *IBMPIVpnConnectionClient) DeleteNetwork(vpnID, networkID string) (*models.JobReference, error) {
+
+	// Create params and send request
+	params := &params.PcloudVpnconnectionsNetworksDeleteParams{
+		Body:            &models.NetworkID{NetworkID: &networkID},
+		CloudInstanceID: f.cloudInstanceID,
+		Context:         f.context,
+		VpnConnectionID: vpnID,
+	}
+	//params.SetTimeout(helpers.PIDeleteTimeOut)
+	resp, err := f.request.PcloudVpnconnectionsNetworksDelete(params, f.auth)
+
+	// Handle errors
 	if err != nil {
-		return nil, fmt.Errorf("failed to Get Subnets from VPN Connection %s: %w", id, err)
+		return nil, fmt.Errorf("failed to Delete Network %s from VPN Connection %s: %w", networkID, vpnID, err)
+	}
+	if resp != nil && resp.Payload != nil {
+		return resp.Payload, nil
+	}
+	return nil, nil
+}
+
+// Get a VPN Connection's Subnet
+func (f *IBMPIVpnConnectionClient) GetSubnet(vpnID string) (*models.PeerSubnets, error) {
+
+	// Create params and send request
+	params := &params.PcloudVpnconnectionsPeersubnetsGetParams{
+		CloudInstanceID: f.cloudInstanceID,
+		Context:         f.context,
+		VpnConnectionID: vpnID,
+	}
+	//params.SetTimeout(helpers.PIGetTimeOut)
+	resp, err := f.request.PcloudVpnconnectionsPeersubnetsGet(params, f.auth)
+
+	// Handle errors
+	if err != nil {
+		return nil, fmt.Errorf("failed to Get Subnets from VPN Connection %s: %w", vpnID, err)
 	}
 	if resp == nil || resp.Payload == nil {
-		return nil, fmt.Errorf("failed to Get Subnets from VPN Connection %s", id)
+		return nil, fmt.Errorf("failed to Get Subnets from VPN Connection %s", vpnID)
 	}
 	return resp.Payload, nil
 }
 
-// Subnet attach
-func (f *IBMPIVpnConnectionClient) AddSubnet(id, subnet string) (*models.PeerSubnets, error) {
-	params := p_cloud_v_p_n_connections.NewPcloudVpnconnectionsPeersubnetsPutParams().
-		WithContext(f.ctx).WithTimeout(helpers.PIUpdateTimeOut).
-		WithCloudInstanceID(f.cloudInstanceID).WithVpnConnectionID(id).
-		WithBody(&models.PeerSubnetUpdate{Cidr: &subnet})
-	resp, err := f.session.Power.PCloudvpnConnections.PcloudVpnconnectionsPeersubnetsPut(params, f.session.AuthInfo(f.cloudInstanceID))
+// Attach a Subnet to a VPN Connection
+func (f *IBMPIVpnConnectionClient) AddSubnet(vpnID, subnet string) (*models.PeerSubnets, error) {
+
+	// Create params and send request
+	params := &params.PcloudVpnconnectionsPeersubnetsPutParams{
+		Body:            &models.PeerSubnetUpdate{Cidr: &subnet},
+		CloudInstanceID: f.cloudInstanceID,
+		Context:         f.context,
+		VpnConnectionID: vpnID,
+	}
+	//params.SetTimeout(helpers.PIUpdateTimeOut)
+	resp, err := f.request.PcloudVpnconnectionsPeersubnetsPut(params, f.auth)
+
+	// Handle errors
 	if err != nil {
-		return nil, fmt.Errorf("failed to Add Subnets to VPN Connection %s: %w", id, err)
+		return nil, fmt.Errorf("failed to Add Subnets to VPN Connection %s: %w", vpnID, err)
 	}
 	if resp == nil || resp.Payload == nil {
-		return nil, fmt.Errorf("failed to Add Subnets to VPN Connection %s", id)
+		return nil, fmt.Errorf("failed to Add Subnets to VPN Connection %s", vpnID)
 	}
 	return resp.Payload, nil
 }
 
-// Subnet detach
-func (f *IBMPIVpnConnectionClient) DeleteSubnet(id, subnet string) (*models.PeerSubnets, error) {
-	params := p_cloud_v_p_n_connections.NewPcloudVpnconnectionsPeersubnetsDeleteParams().
-		WithContext(f.ctx).WithTimeout(helpers.PIDeleteTimeOut).
-		WithCloudInstanceID(f.cloudInstanceID).WithVpnConnectionID(id).
-		WithBody(&models.PeerSubnetUpdate{Cidr: &subnet})
-	resp, err := f.session.Power.PCloudvpnConnections.PcloudVpnconnectionsPeersubnetsDelete(params, f.session.AuthInfo(f.cloudInstanceID))
+// Detach a Subnet from a VPN Connection
+func (f *IBMPIVpnConnectionClient) DeleteSubnet(vpnID, subnet string) (*models.PeerSubnets, error) {
+
+	// Create params and send request
+	params := &params.PcloudVpnconnectionsPeersubnetsDeleteParams{
+		Body:            &models.PeerSubnetUpdate{Cidr: &subnet},
+		CloudInstanceID: f.cloudInstanceID,
+		Context:         f.context,
+		VpnConnectionID: vpnID,
+	}
+	//params.SetTimeout(helpers.PIDeleteTimeOut)
+	resp, err := f.request.PcloudVpnconnectionsPeersubnetsDelete(params, f.auth)
+
+	// Handle errors
 	if err != nil {
-		return nil, fmt.Errorf("failed to Delete Subnet from VPN Connection %s: %w", id, err)
+		return nil, fmt.Errorf("failed to Delete Subnet from VPN Connection %s: %w", vpnID, err)
 	}
 	if resp == nil || resp.Payload == nil {
-		return nil, fmt.Errorf("failed to Delete Subnet from VPN Connection %s", id)
+		return nil, fmt.Errorf("failed to Delete Subnet from VPN Connection %s", vpnID)
 	}
 	return resp.Payload, nil
 }


### PR DESCRIPTION
- Create Params with structs instead of a function
- Use default service broker timeout (previous timeout is commented out)
- Eliminate need for `IBMPIClient` and `ibm_pi_helper.go`
  - I plan on removing these in a different PR