### PR TITLE
Cleaned up Volume

### DIFF
--- a/clients/instance/ibm-pi-volume.go
+++ b/clients/instance/ibm-pi-volume.go
@@ -5,46 +5,64 @@ import (
 	"fmt"
 
 	"github.com/IBM-Cloud/power-go-client/errors"
-
-	"github.com/IBM-Cloud/power-go-client/helpers"
 	"github.com/IBM-Cloud/power-go-client/ibmpisession"
-	"github.com/IBM-Cloud/power-go-client/power/client/p_cloud_volumes"
+	params "github.com/IBM-Cloud/power-go-client/power/client/p_cloud_volumes"
 	"github.com/IBM-Cloud/power-go-client/power/models"
+	"github.com/go-openapi/runtime"
 )
 
 // IBMPIVolumeClient ..
 type IBMPIVolumeClient struct {
-	IBMPIClient
+	auth            runtime.ClientAuthInfoWriter
+	cloudInstanceID string
+	context         context.Context
+	request         params.ClientService
 }
 
 // NewIBMPIVolumeClient ...
 func NewIBMPIVolumeClient(ctx context.Context, sess *ibmpisession.IBMPISession, cloudInstanceID string) *IBMPIVolumeClient {
 	return &IBMPIVolumeClient{
-		*NewIBMPIClient(ctx, sess, cloudInstanceID),
+		auth:            sess.AuthInfo(cloudInstanceID),
+		cloudInstanceID: cloudInstanceID,
+		context:         ctx,
+		request:         sess.Power.PCloudVolumes,
 	}
 }
 
-//Get information about a single volume only
-func (f *IBMPIVolumeClient) Get(id string) (*models.Volume, error) {
-	params := p_cloud_volumes.NewPcloudCloudinstancesVolumesGetParams().
-		WithContext(f.ctx).WithTimeout(helpers.PIGetTimeOut).
-		WithCloudInstanceID(f.cloudInstanceID).WithVolumeID(id)
-	resp, err := f.session.Power.PCloudVolumes.PcloudCloudinstancesVolumesGet(params, f.session.AuthInfo(f.cloudInstanceID))
+// Get a Volume
+func (f *IBMPIVolumeClient) Get(volumeID string) (*models.Volume, error) {
+
+	// Create params and send request
+	params := &params.PcloudCloudinstancesVolumesGetParams{
+		CloudInstanceID: f.cloudInstanceID,
+		Context:         f.context,
+		VolumeID:        volumeID,
+	}
+	//params.SetTimeout(helpers.PIGetTimeOut)
+	resp, err := f.request.PcloudCloudinstancesVolumesGet(params, f.auth)
+
+	// Handle errors
 	if err != nil {
-		return nil, fmt.Errorf(errors.GetVolumeOperationFailed, id, err)
+		return nil, fmt.Errorf(errors.GetVolumeOperationFailed, volumeID, err)
 	}
 	if resp == nil || resp.Payload == nil {
-		return nil, fmt.Errorf("failed to Get Volume %s", id)
+		return nil, fmt.Errorf("failed to Get Volume %s", volumeID)
 	}
 	return resp.Payload, nil
 }
 
-// GetAll volumes
+// Get All Volumes
 func (f *IBMPIVolumeClient) GetAll() (*models.Volumes, error) {
-	params := p_cloud_volumes.NewPcloudCloudinstancesVolumesGetallParams().
-		WithContext(f.ctx).WithTimeout(helpers.PIGetTimeOut).
-		WithCloudInstanceID(f.cloudInstanceID)
-	resp, err := f.session.Power.PCloudVolumes.PcloudCloudinstancesVolumesGetall(params, f.session.AuthInfo(f.cloudInstanceID))
+
+	// Create params and send request
+	params := &params.PcloudCloudinstancesVolumesGetallParams{
+		CloudInstanceID: f.cloudInstanceID,
+		Context:         f.context,
+	}
+	//params.SetTimeout(helpers.PIGetTimeOut)
+	resp, err := f.request.PcloudCloudinstancesVolumesGetall(params, f.auth)
+
+	// Handle errors
 	if err != nil {
 		return nil, fmt.Errorf("failed to Get all Volumes for Cloud Instance %s: %w", f.cloudInstanceID, err)
 	}
@@ -54,12 +72,19 @@ func (f *IBMPIVolumeClient) GetAll() (*models.Volumes, error) {
 	return resp.Payload, nil
 }
 
-// GetAll volumes
+// Get All Affinity Volumes
 func (f *IBMPIVolumeClient) GetAllAffinityVolumes(affinity string) (*models.Volumes, error) {
-	params := p_cloud_volumes.NewPcloudCloudinstancesVolumesGetallParams().
-		WithContext(f.ctx).WithTimeout(helpers.PIGetTimeOut).
-		WithCloudInstanceID(f.cloudInstanceID).WithAffinity(&affinity)
-	resp, err := f.session.Power.PCloudVolumes.PcloudCloudinstancesVolumesGetall(params, f.session.AuthInfo(f.cloudInstanceID))
+
+	// Create params and send request
+	params := &params.PcloudCloudinstancesVolumesGetallParams{
+		Affinity:        &affinity,
+		CloudInstanceID: f.cloudInstanceID,
+		Context:         f.context,
+	}
+	//params.SetTimeout(helpers.PIGetTimeOut)
+	resp, err := f.request.PcloudCloudinstancesVolumesGetall(params, f.auth)
+
+	// Handle errors
 	if err != nil {
 		return nil, fmt.Errorf("failed to Get all Volumes with affinity %s for Cloud Instance %s: %w", affinity, f.cloudInstanceID, err)
 	}
@@ -69,14 +94,21 @@ func (f *IBMPIVolumeClient) GetAllAffinityVolumes(affinity string) (*models.Volu
 	return resp.Payload, nil
 }
 
-//CreateVolumeV2 ...
-func (f *IBMPIVolumeClient) CreateVolumeV2(body *models.MultiVolumesCreate) (*models.Volumes, error) {
-	params := p_cloud_volumes.NewPcloudV2VolumesPostParams().
-		WithContext(f.ctx).WithTimeout(helpers.PICreateTimeOut).
-		WithCloudInstanceID(f.cloudInstanceID).WithBody(body)
-	resp, err := f.session.Power.PCloudVolumes.PcloudV2VolumesPost(params, f.session.AuthInfo(f.cloudInstanceID))
+// Create a VolumeV2
+func (f *IBMPIVolumeClient) CreateVolumeV2(createBody *models.MultiVolumesCreate) (*models.Volumes, error) {
+
+	// Create params and send request
+	params := &params.PcloudV2VolumesPostParams{
+		Body:            createBody,
+		CloudInstanceID: f.cloudInstanceID,
+		Context:         f.context,
+	}
+	//params.SetTimeout(helpers.PICreateTimeOut)
+	resp, err := f.request.PcloudV2VolumesPost(params, f.auth)
+
+	// Handle errors
 	if err != nil {
-		return nil, fmt.Errorf(errors.CreateVolumeV2OperationFailed, *body.Name, err)
+		return nil, fmt.Errorf(errors.CreateVolumeV2OperationFailed, *createBody.Name, err)
 	}
 	if resp == nil || resp.Payload == nil {
 		return nil, fmt.Errorf("failed to Create Volume v2")
@@ -84,14 +116,21 @@ func (f *IBMPIVolumeClient) CreateVolumeV2(body *models.MultiVolumesCreate) (*mo
 	return resp.Payload, nil
 }
 
-// CreateVolume ...
-func (f *IBMPIVolumeClient) CreateVolume(body *models.CreateDataVolume) (*models.Volume, error) {
-	params := p_cloud_volumes.NewPcloudCloudinstancesVolumesPostParams().
-		WithContext(f.ctx).WithTimeout(helpers.PICreateTimeOut).
-		WithCloudInstanceID(f.cloudInstanceID).WithBody(body)
-	resp, err := f.session.Power.PCloudVolumes.PcloudCloudinstancesVolumesPost(params, f.session.AuthInfo(f.cloudInstanceID))
+// Create a Volume
+func (f *IBMPIVolumeClient) CreateVolume(createBody *models.CreateDataVolume) (*models.Volume, error) {
+
+	// Create params and send request
+	params := &params.PcloudCloudinstancesVolumesPostParams{
+		Body:            createBody,
+		CloudInstanceID: f.cloudInstanceID,
+		Context:         f.context,
+	}
+	//params.SetTimeout(helpers.PICreateTimeOut)
+	resp, err := f.request.PcloudCloudinstancesVolumesPost(params, f.auth)
+
+	// Handle errors
 	if err != nil {
-		return nil, fmt.Errorf(errors.CreateVolumeOperationFailed, *body.Name, err)
+		return nil, fmt.Errorf(errors.CreateVolumeOperationFailed, *createBody.Name, err)
 	}
 	if resp == nil || resp.Payload == nil {
 		return nil, fmt.Errorf("failed to Create Volume")
@@ -99,116 +138,173 @@ func (f *IBMPIVolumeClient) CreateVolume(body *models.CreateDataVolume) (*models
 	return resp.Payload, nil
 }
 
-// UpdateVolume ...
-func (f *IBMPIVolumeClient) UpdateVolume(id string, body *models.UpdateVolume) (*models.Volume, error) {
-	params := p_cloud_volumes.NewPcloudCloudinstancesVolumesPutParams().
-		WithContext(f.ctx).WithTimeout(helpers.PIUpdateTimeOut).
-		WithCloudInstanceID(f.cloudInstanceID).WithVolumeID(id).
-		WithBody(body)
-	resp, err := f.session.Power.PCloudVolumes.PcloudCloudinstancesVolumesPut(params, f.session.AuthInfo(f.cloudInstanceID))
+// Update a Volume
+func (f *IBMPIVolumeClient) UpdateVolume(volumeID string, updateBody *models.UpdateVolume) (*models.Volume, error) {
+
+	// Create params and send request
+	params := &params.PcloudCloudinstancesVolumesPutParams{
+		Body:            updateBody,
+		CloudInstanceID: f.cloudInstanceID,
+		Context:         f.context,
+		VolumeID:        volumeID,
+	}
+	//params.SetTimeout(helpers.PIUpdateTimeOut)
+	resp, err := f.request.PcloudCloudinstancesVolumesPut(params, f.auth)
+
+	// Handle errors
 	if err != nil {
-		return nil, fmt.Errorf(errors.UpdateVolumeOperationFailed, id, err)
+		return nil, fmt.Errorf(errors.UpdateVolumeOperationFailed, volumeID, err)
 	}
 	if resp == nil || resp.Payload == nil {
-		return nil, fmt.Errorf("failed to Update Volume %s", id)
+		return nil, fmt.Errorf("failed to Update Volume %s", volumeID)
 	}
 	return resp.Payload, nil
 }
 
-// DeleteVolume ...
-func (f *IBMPIVolumeClient) DeleteVolume(id string) error {
-	params := p_cloud_volumes.NewPcloudCloudinstancesVolumesDeleteParams().
-		WithContext(f.ctx).WithTimeout(helpers.PIDeleteTimeOut).
-		WithCloudInstanceID(f.cloudInstanceID).WithVolumeID(id)
-	_, err := f.session.Power.PCloudVolumes.PcloudCloudinstancesVolumesDelete(params, f.session.AuthInfo(f.cloudInstanceID))
+// Delete a Volume
+func (f *IBMPIVolumeClient) DeleteVolume(volumeID string) error {
+
+	// Create params and send request
+	params := &params.PcloudCloudinstancesVolumesDeleteParams{
+		CloudInstanceID: f.cloudInstanceID,
+		Context:         f.context,
+		VolumeID:        volumeID,
+	}
+	//params.SetTimeout(helpers.PIDeleteTimeOut)
+	_, err := f.request.PcloudCloudinstancesVolumesDelete(params, f.auth)
+
+	// Handle errors
 	if err != nil {
-		return fmt.Errorf(errors.DeleteVolumeOperationFailed, id, err)
+		return fmt.Errorf(errors.DeleteVolumeOperationFailed, volumeID, err)
 	}
 	return nil
 }
 
-// Attach a volume
-func (f *IBMPIVolumeClient) Attach(id, volumename string) error {
-	params := p_cloud_volumes.NewPcloudPvminstancesVolumesPostParams().
-		WithContext(f.ctx).WithTimeout(helpers.PICreateTimeOut).
-		WithCloudInstanceID(f.cloudInstanceID).WithPvmInstanceID(id).
-		WithVolumeID(volumename)
-	_, err := f.session.Power.PCloudVolumes.PcloudPvminstancesVolumesPost(params, f.session.AuthInfo(f.cloudInstanceID))
+// Attach a Volume to an Instance
+func (f *IBMPIVolumeClient) Attach(instanceID, volumeID string) error {
+
+	// Create params and send request
+	params := &params.PcloudPvminstancesVolumesPostParams{
+		CloudInstanceID: f.cloudInstanceID,
+		Context:         f.context,
+		PvmInstanceID:   instanceID,
+		VolumeID:        volumeID,
+	}
+	//params.SetTimeout(helpers.PICreateTimeOut)
+	_, err := f.request.PcloudPvminstancesVolumesPost(params, f.auth)
+
+	// Handle errors
 	if err != nil {
-		return fmt.Errorf(errors.AttachVolumeOperationFailed, volumename, err)
+		return fmt.Errorf(errors.AttachVolumeOperationFailed, volumeID, err)
 	}
 	return nil
 }
 
-//Detach a volume
-func (f *IBMPIVolumeClient) Detach(id, volumename string) error {
-	params := p_cloud_volumes.NewPcloudPvminstancesVolumesDeleteParams().
-		WithContext(f.ctx).WithTimeout(helpers.PICreateTimeOut).
-		WithCloudInstanceID(f.cloudInstanceID).WithPvmInstanceID(id).
-		WithVolumeID(volumename)
-	_, err := f.session.Power.PCloudVolumes.PcloudPvminstancesVolumesDelete(params, f.session.AuthInfo(f.cloudInstanceID))
+// Detach a Volume from an Instance
+func (f *IBMPIVolumeClient) Detach(instanceID, volumeID string) error {
+
+	// Create params and send request
+	params := &params.PcloudPvminstancesVolumesDeleteParams{
+		CloudInstanceID: f.cloudInstanceID,
+		Context:         f.context,
+		PvmInstanceID:   instanceID,
+		VolumeID:        volumeID,
+	}
+	//params.SetTimeout(helpers.PICreateTimeOut)
+	_, err := f.request.PcloudPvminstancesVolumesDelete(params, f.auth)
+
+	// Handle errors
 	if err != nil {
-		return fmt.Errorf(errors.DetachVolumeOperationFailed, volumename, err)
+		return fmt.Errorf(errors.DetachVolumeOperationFailed, volumeID, err)
 	}
 	return nil
 }
 
-// GetAll volumes part of an instance
-func (f *IBMPIVolumeClient) GetAllInstanceVolumes(id string) (*models.Volumes, error) {
-	params := p_cloud_volumes.NewPcloudPvminstancesVolumesGetallParams().
-		WithContext(f.ctx).WithTimeout(helpers.PIGetTimeOut).
-		WithCloudInstanceID(f.cloudInstanceID).WithPvmInstanceID(id)
-	resp, err := f.session.Power.PCloudVolumes.PcloudPvminstancesVolumesGetall(params, f.session.AuthInfo(f.cloudInstanceID))
+// Get All Volumes attached to an Instance
+func (f *IBMPIVolumeClient) GetAllInstanceVolumes(instanceID string) (*models.Volumes, error) {
+
+	// Create params and send request
+	params := &params.PcloudPvminstancesVolumesGetallParams{
+		CloudInstanceID: f.cloudInstanceID,
+		Context:         f.context,
+		PvmInstanceID:   instanceID,
+	}
+	//params.SetTimeout(helpers.PIGetTimeOut)
+	resp, err := f.request.PcloudPvminstancesVolumesGetall(params, f.auth)
+
+	// Handle errors
 	if err != nil {
-		return nil, fmt.Errorf("failed to Get all Volumes for PI Instance %s: %w", id, err)
+		return nil, fmt.Errorf("failed to Get all Volumes for PI Instance %s: %w", instanceID, err)
 	}
 	if resp == nil || resp.Payload == nil {
-		return nil, fmt.Errorf("failed to Get all Volumes for PI Instance %s", id)
+		return nil, fmt.Errorf("failed to Get all Volumes for PI Instance %s", instanceID)
 	}
 	return resp.Payload, nil
 }
 
-// SetBootVolume as the boot volume - PUT Operation
-func (f *IBMPIVolumeClient) SetBootVolume(id, volumename string) error {
-	params := p_cloud_volumes.NewPcloudPvminstancesVolumesSetbootPutParams().
-		WithContext(f.ctx).WithTimeout(helpers.PICreateTimeOut).
-		WithCloudInstanceID(f.cloudInstanceID).WithPvmInstanceID(id).
-		WithVolumeID(volumename)
-	_, err := f.session.Power.PCloudVolumes.PcloudPvminstancesVolumesSetbootPut(params, f.session.AuthInfo(f.cloudInstanceID))
+// Set a Volume as the Boot Volume for an Instance
+func (f *IBMPIVolumeClient) SetBootVolume(instanceID, volumeID string) error {
+
+	// Create params and send request
+	params := &params.PcloudPvminstancesVolumesSetbootPutParams{
+		CloudInstanceID: f.cloudInstanceID,
+		Context:         f.context,
+		PvmInstanceID:   instanceID,
+		VolumeID:        volumeID,
+	}
+	//params.SetTimeout(helpers.PICreateTimeOut)
+	_, err := f.request.PcloudPvminstancesVolumesSetbootPut(params, f.auth)
+
+	// Handle errors
 	if err != nil {
-		return fmt.Errorf("failed to set the boot volume %s for instance %s", volumename, id)
+		return fmt.Errorf("failed to set the boot volume %s for instance %s", volumeID, instanceID)
 	}
 	return nil
 }
 
-// CheckVolumeAttach if the volume is attached to the instance
-func (f *IBMPIVolumeClient) CheckVolumeAttach(id, volumeID string) (*models.Volume, error) {
-	params := p_cloud_volumes.NewPcloudPvminstancesVolumesGetParams().
-		WithContext(f.ctx).WithTimeout(helpers.PIGetTimeOut).
-		WithCloudInstanceID(f.cloudInstanceID).WithPvmInstanceID(id).
-		WithVolumeID(volumeID)
-	resp, err := f.session.Power.PCloudVolumes.PcloudPvminstancesVolumesGet(params, f.session.AuthInfo(f.cloudInstanceID))
+// Check if a Volume is attached to an Instance
+func (f *IBMPIVolumeClient) CheckVolumeAttach(instanceID, volumeID string) (*models.Volume, error) {
+
+	// Create params and send request
+	params := &params.PcloudPvminstancesVolumesGetParams{
+		CloudInstanceID: f.cloudInstanceID,
+		Context:         f.context,
+		PvmInstanceID:   instanceID,
+		VolumeID:        volumeID,
+	}
+	//params.SetTimeout(helpers.PIGetTimeOut)
+	resp, err := f.request.PcloudPvminstancesVolumesGet(params, f.auth)
+
+	// Handle errors
 	if err != nil {
-		return nil, fmt.Errorf("failed to validate that the volume %s is attached to the pvminstance %s: %w", volumeID, id, err)
+		return nil, fmt.Errorf("failed to validate that the volume %s is attached to the pvminstance %s: %w", volumeID, instanceID, err)
 	}
 	if resp == nil || resp.Payload == nil {
-		return nil, fmt.Errorf("failed to validate that the volume %s is attached to the pvminstance %s", volumeID, id)
+		return nil, fmt.Errorf("failed to validate that the volume %s is attached to the pvminstance %s", volumeID, instanceID)
 	}
 	return resp.Payload, nil
 }
 
-// UpdateVolumeAttach if the volume is attached to the instance
-func (f *IBMPIVolumeClient) UpdateVolumeAttach(id, volumeID string, body *models.PVMInstanceVolumeUpdate) error {
-	params := p_cloud_volumes.NewPcloudPvminstancesVolumesPutParams().
-		WithContext(f.ctx).WithTimeout(helpers.PIUpdateTimeOut).
-		WithCloudInstanceID(f.cloudInstanceID).WithPvmInstanceID(id).
-		WithVolumeID(volumeID).WithBody(body)
-	resp, err := f.session.Power.PCloudVolumes.PcloudPvminstancesVolumesPut(params, f.session.AuthInfo(f.cloudInstanceID))
+// Update a Volume attached to an Instance
+func (f *IBMPIVolumeClient) UpdateVolumeAttach(instanceID, volumeID string, body *models.PVMInstanceVolumeUpdate) error {
+
+	// Create params and send request
+	params := &params.PcloudPvminstancesVolumesPutParams{
+		Body:            body,
+		CloudInstanceID: f.cloudInstanceID,
+		Context:         f.context,
+		PvmInstanceID:   instanceID,
+		VolumeID:        volumeID,
+	}
+	//params.SetTimeout(helpers.PIUpdateTimeOut)
+	resp, err := f.request.PcloudPvminstancesVolumesPut(params, f.auth)
+
+	// Handle errors
 	if err != nil {
-		return fmt.Errorf("failed to validate that the volume %s is attached to the pvminstance %s: %w", volumeID, id, err)
+		return fmt.Errorf("failed to validate that the volume %s is attached to the pvminstance %s: %w", volumeID, instanceID, err)
 	}
 	if resp == nil || resp.Payload == nil {
-		return fmt.Errorf("failed to validate that the volume %s is attached to the pvminstance %s", volumeID, id)
+		return fmt.Errorf("failed to validate that the volume %s is attached to the pvminstance %s", volumeID, instanceID)
 	}
 	return nil
 }


### PR DESCRIPTION
- Create Params with structs instead of a function
- Use default service broker timeout (previous timeout is commented out)
- Eliminate need for `IBMPIClient` and `ibm_pi_helper.go`
  - I plan on removing these in a different PR