### PR TITLE
Cleaned up Tenant

### DIFF
--- a/clients/instance/ibm-pi-tenant.go
+++ b/clients/instance/ibm-pi-tenant.go
@@ -4,45 +4,63 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/IBM-Cloud/power-go-client/helpers"
 	"github.com/IBM-Cloud/power-go-client/ibmpisession"
-	"github.com/IBM-Cloud/power-go-client/power/client/p_cloud_tenants"
+	params "github.com/IBM-Cloud/power-go-client/power/client/p_cloud_tenants"
 	"github.com/IBM-Cloud/power-go-client/power/models"
+	"github.com/go-openapi/runtime"
 )
 
 // IBMPITenantClient ...
 type IBMPITenantClient struct {
-	IBMPIClient
+	auth     runtime.ClientAuthInfoWriter
+	context  context.Context
+	request  params.ClientService
+	tenantID string
 }
 
 // NewIBMPITenantClient ...
 func NewIBMPITenantClient(ctx context.Context, sess *ibmpisession.IBMPISession, cloudInstanceID string) *IBMPITenantClient {
 	return &IBMPITenantClient{
-		*NewIBMPIClient(ctx, sess, cloudInstanceID),
+		auth:     sess.AuthInfo(cloudInstanceID),
+		context:  ctx,
+		request:  sess.Power.PCloudTenants,
+		tenantID: sess.Options.UserAccount,
 	}
 }
 
-// Get ..
-func (f *IBMPITenantClient) Get(tenantid string) (*models.Tenant, error) {
-	params := p_cloud_tenants.NewPcloudTenantsGetParams().
-		WithContext(f.ctx).WithTimeout(helpers.PIGetTimeOut).
-		WithTenantID(tenantid)
-	resp, err := f.session.Power.PCloudTenants.PcloudTenantsGet(params, f.session.AuthInfo(f.cloudInstanceID))
+// Get a Tenant
+func (f *IBMPITenantClient) Get(tenantID string) (*models.Tenant, error) {
+
+	// Create params and send request
+	params := &params.PcloudTenantsGetParams{
+		Context:  f.context,
+		TenantID: tenantID,
+	}
+	//params.SetTimeout(helpers.PIGetTimeOut)
+	resp, err := f.request.PcloudTenantsGet(params, f.auth)
+
+	// Handle errors
 	if err != nil {
-		return nil, fmt.Errorf("failed to get tenant %s with error %w", tenantid, err)
+		return nil, fmt.Errorf("failed to get tenant %s with error %w", tenantID, err)
 	}
 	if resp == nil || resp.Payload == nil {
-		return nil, fmt.Errorf("failed to get tenant %s", tenantid)
+		return nil, fmt.Errorf("failed to get tenant %s", tenantID)
 	}
 	return resp.Payload, nil
 }
 
-// Get ..
+// Get own Tenant
 func (f *IBMPITenantClient) GetSelfTenant() (*models.Tenant, error) {
-	params := p_cloud_tenants.NewPcloudTenantsGetParams().
-		WithContext(f.ctx).WithTimeout(helpers.PIGetTimeOut).
-		WithTenantID(f.session.Options.UserAccount)
-	resp, err := f.session.Power.PCloudTenants.PcloudTenantsGet(params, f.session.AuthInfo(f.cloudInstanceID))
+
+	// Create params and send request
+	params := &params.PcloudTenantsGetParams{
+		TenantID: f.tenantID,
+		Context:  f.context,
+	}
+	//params.SetTimeout(helpers.PIGetTimeOut)
+	resp, err := f.request.PcloudTenantsGet(params, f.auth)
+
+	// Handle errors
 	if err != nil {
 		return nil, fmt.Errorf("failed to get self tenant with error %w", err)
 	}


### PR DESCRIPTION
- Create Params with structs instead of a function
- Use default service broker timeout (previous timeout is commented out)
- Eliminate need for `IBMPIClient` and `ibm_pi_helper.go`
  - I plan on removing these in a different PR