### PR TITLE
Cleaned up Task

### DIFF
--- a/clients/instance/ibm-pi-tasks.go
+++ b/clients/instance/ibm-pi-tasks.go
@@ -4,42 +4,58 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/IBM-Cloud/power-go-client/helpers"
 	"github.com/IBM-Cloud/power-go-client/ibmpisession"
-	"github.com/IBM-Cloud/power-go-client/power/client/p_cloud_tasks"
+	params "github.com/IBM-Cloud/power-go-client/power/client/p_cloud_tasks"
 	"github.com/IBM-Cloud/power-go-client/power/models"
+	"github.com/go-openapi/runtime"
 )
 
 // IBMPITaskClient ...
 type IBMPITaskClient struct {
-	IBMPIClient
+	auth    runtime.ClientAuthInfoWriter
+	context context.Context
+	request params.ClientService
 }
 
 // NewIBMPITaskClient ...
 func NewIBMPITaskClient(ctx context.Context, sess *ibmpisession.IBMPISession, cloudInstanceID string) *IBMPITaskClient {
 	return &IBMPITaskClient{
-		*NewIBMPIClient(ctx, sess, cloudInstanceID),
+		auth:    sess.AuthInfo(cloudInstanceID),
+		context: ctx,
+		request: sess.Power.PCloudTasks,
 	}
 }
 
-// Get ...
-func (f *IBMPITaskClient) Get(id string) (*models.Task, error) {
-	params := p_cloud_tasks.NewPcloudTasksGetParams().
-		WithContext(f.ctx).WithTimeout(helpers.PIGetTimeOut).
-		WithTaskID(id)
-	resp, err := f.session.Power.PCloudTasks.PcloudTasksGet(params, f.session.AuthInfo(f.cloudInstanceID))
+// Get a Task
+func (f *IBMPITaskClient) Get(taskID string) (*models.Task, error) {
+
+	// Create params and send request
+	params := &params.PcloudTasksGetParams{
+		Context: f.context,
+		TaskID:  taskID,
+	}
+	//params.SetTimeout(helpers.PIGetTimeOut)
+	resp, err := f.request.PcloudTasksGet(params, f.auth)
+
+	// Handle errors
 	if err != nil || resp.Payload == nil {
-		return nil, fmt.Errorf("failed to get the task %s: %w", id, err)
+		return nil, fmt.Errorf("failed to get the task %s: %w", taskID, err)
 	}
 	return resp.Payload, nil
 }
 
-// Delete ...
-func (f *IBMPITaskClient) Delete(id string) error {
-	params := p_cloud_tasks.NewPcloudTasksDeleteParams().
-		WithContext(f.ctx).WithTimeout(helpers.PIDeleteTimeOut).
-		WithTaskID(id)
-	_, err := f.session.Power.PCloudTasks.PcloudTasksDelete(params, f.session.AuthInfo(f.cloudInstanceID))
+// Delete a Task
+func (f *IBMPITaskClient) Delete(taskID string) error {
+
+	// Create params and send request
+	params := &params.PcloudTasksDeleteParams{
+		Context: f.context,
+		TaskID:  taskID,
+	}
+	//params.SetTimeout(helpers.PIDeleteTimeOut)
+	_, err := f.request.PcloudTasksDelete(params, f.auth)
+
+	// Handle errors
 	if err != nil {
 		return fmt.Errorf("failed to delete the task id ... %w", err)
 	}


### PR DESCRIPTION
- Create Params with structs instead of a function
- Use default service broker timeout (previous timeout is commented out)
- Eliminated need for `IBMPIClient` and `ibm_pi_helper.go`
  - I plan on removing these in a different PR