### PR TITLE
Cleaned up System Pool

### DIFF
--- a/clients/instance/ibm-pi-system-pools.go
+++ b/clients/instance/ibm-pi-system-pools.go
@@ -5,36 +5,45 @@ import (
 	"fmt"
 
 	"github.com/IBM-Cloud/power-go-client/errors"
-	"github.com/IBM-Cloud/power-go-client/helpers"
-
 	"github.com/IBM-Cloud/power-go-client/ibmpisession"
-	"github.com/IBM-Cloud/power-go-client/power/client/p_cloud_system_pools"
+	params "github.com/IBM-Cloud/power-go-client/power/client/p_cloud_system_pools"
 	"github.com/IBM-Cloud/power-go-client/power/models"
+	"github.com/go-openapi/runtime"
 )
 
 // IBMPISystemPoolClient ...
 type IBMPISystemPoolClient struct {
-	IBMPIClient
+	auth    runtime.ClientAuthInfoWriter
+	context context.Context
+	request params.ClientService
 }
 
 // NewIBMPISystemPoolClient ...
 func NewIBMPISystemPoolClient(ctx context.Context, sess *ibmpisession.IBMPISession, cloudInstanceID string) *IBMPISystemPoolClient {
 	return &IBMPISystemPoolClient{
-		*NewIBMPIClient(ctx, sess, cloudInstanceID),
+		auth:    sess.AuthInfo(cloudInstanceID),
+		context: ctx,
+		request: sess.Power.PCloudSystemPools,
 	}
 }
 
-//Get the System Pools
-func (f *IBMPISystemPoolClient) Get(id string) (models.SystemPools, error) {
-	params := p_cloud_system_pools.NewPcloudSystempoolsGetParams().
-		WithContext(f.ctx).WithTimeout(helpers.PIGetTimeOut).
-		WithCloudInstanceID(id)
-	resp, err := f.session.Power.PCloudSystemPools.PcloudSystempoolsGet(params, f.session.AuthInfo(f.cloudInstanceID))
+// Get a System Pool
+func (f *IBMPISystemPoolClient) Get(cloudInstanceID string) (models.SystemPools, error) {
+
+	// Create params and send request
+	params := &params.PcloudSystempoolsGetParams{
+		CloudInstanceID: cloudInstanceID,
+		Context:         f.context,
+	}
+	//params.SetTimeout(helpers.PIGetTimeOut)
+	resp, err := f.request.PcloudSystempoolsGet(params, f.auth)
+
+	// Handle errors
 	if err != nil {
-		return nil, fmt.Errorf(errors.GetSystemPoolsOperationFailed, id, err)
+		return nil, fmt.Errorf(errors.GetSystemPoolsOperationFailed, cloudInstanceID, err)
 	}
 	if resp == nil || resp.Payload == nil {
-		return nil, fmt.Errorf("failed to perform Get System Pools Operation for cloud instance id %s", id)
+		return nil, fmt.Errorf("failed to perform Get System Pools Operation for cloud instance id %s", cloudInstanceID)
 	}
 	return resp.Payload, nil
 }


### PR DESCRIPTION
- Create Params with structs instead of a function
- Use default service broker timeout (previous timeout is commented out)
- Eliminated need for `IBMPIClient` and `ibm_pi_helper.go`
  - I plan on removing these in a different PR