### PR TITLE
Cleaned up Storage Capacity

### DIFF
--- a/clients/instance/ibm-pi-storage-capacity.go
+++ b/clients/instance/ibm-pi-storage-capacity.go
@@ -4,30 +4,42 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/IBM-Cloud/power-go-client/helpers"
 	"github.com/IBM-Cloud/power-go-client/ibmpisession"
-	"github.com/IBM-Cloud/power-go-client/power/client/p_cloud_storage_capacity"
+	params "github.com/IBM-Cloud/power-go-client/power/client/p_cloud_storage_capacity"
 	"github.com/IBM-Cloud/power-go-client/power/models"
+	"github.com/go-openapi/runtime"
 )
 
 // IBMPIStorageCapacityClient ..
 type IBMPIStorageCapacityClient struct {
-	IBMPIClient
+	auth            runtime.ClientAuthInfoWriter
+	cloudInstanceID string
+	context         context.Context
+	request         params.ClientService
 }
 
 // NewIBMPIStorageCapacityClient ...
 func NewIBMPIStorageCapacityClient(ctx context.Context, sess *ibmpisession.IBMPISession, cloudInstanceID string) *IBMPIStorageCapacityClient {
 	return &IBMPIStorageCapacityClient{
-		*NewIBMPIClient(ctx, sess, cloudInstanceID),
+		auth:            sess.AuthInfo(cloudInstanceID),
+		cloudInstanceID: cloudInstanceID,
+		context:         ctx,
+		request:         sess.Power.PCloudStorageCapacity,
 	}
 }
 
-//Storage capacity for all available storage pools in a region
+// Get All Storage Capacities for all available Storage Pools in a Region
 func (f *IBMPIStorageCapacityClient) GetAllStoragePoolsCapacity() (*models.StoragePoolsCapacity, error) {
-	params := p_cloud_storage_capacity.NewPcloudStoragecapacityPoolsGetallParams().
-		WithContext(f.ctx).WithTimeout(helpers.PIGetTimeOut).
-		WithCloudInstanceID(f.cloudInstanceID)
-	resp, err := f.session.Power.PCloudStorageCapacity.PcloudStoragecapacityPoolsGetall(params, f.session.AuthInfo(f.cloudInstanceID))
+
+	// Create params and send request
+	params := &params.PcloudStoragecapacityPoolsGetallParams{
+		CloudInstanceID: f.cloudInstanceID,
+		Context:         f.context,
+	}
+	//params.SetTimeout(helpers.PIGetTimeOut)
+	resp, err := f.request.PcloudStoragecapacityPoolsGetall(params, f.auth)
+
+	// Handle errors
 	if err != nil {
 		return nil, fmt.Errorf("failed to get the capacity for all storage pools: %w", err)
 	}
@@ -37,12 +49,19 @@ func (f *IBMPIStorageCapacityClient) GetAllStoragePoolsCapacity() (*models.Stora
 	return resp.Payload, nil
 }
 
-// Storage capacity for a storage pool in a region
+// Get Storage Capacity for a Storage Pool in a Region
 func (f *IBMPIStorageCapacityClient) GetStoragePoolCapacity(storagePool string) (*models.StoragePoolCapacity, error) {
-	params := p_cloud_storage_capacity.NewPcloudStoragecapacityPoolsGetParams().
-		WithContext(f.ctx).WithTimeout(helpers.PIGetTimeOut).
-		WithCloudInstanceID(f.cloudInstanceID).WithStoragePoolName(storagePool)
-	resp, err := f.session.Power.PCloudStorageCapacity.PcloudStoragecapacityPoolsGet(params, f.session.AuthInfo(f.cloudInstanceID))
+
+	// Create params and send request
+	params := &params.PcloudStoragecapacityPoolsGetParams{
+		CloudInstanceID: f.cloudInstanceID,
+		Context:         f.context,
+		StoragePoolName: storagePool,
+	}
+	//params.SetTimeout(helpers.PIGetTimeOut)
+	resp, err := f.request.PcloudStoragecapacityPoolsGet(params, f.auth)
+
+	// Handle errors
 	if err != nil {
 		return nil, fmt.Errorf("failed to get the capacity for storage pool %s: %w", storagePool, err)
 	}
@@ -52,12 +71,19 @@ func (f *IBMPIStorageCapacityClient) GetStoragePoolCapacity(storagePool string) 
 	return resp.Payload, nil
 }
 
-// Storage capacity for a storage type in a region
+// Get Storage capacity for a Storage Type in a Region
 func (f *IBMPIStorageCapacityClient) GetStorageTypeCapacity(storageType string) (*models.StorageTypeCapacity, error) {
-	params := p_cloud_storage_capacity.NewPcloudStoragecapacityTypesGetParams().
-		WithContext(f.ctx).WithTimeout(helpers.PIGetTimeOut).
-		WithCloudInstanceID(f.cloudInstanceID).WithStorageTypeName(storageType)
-	resp, err := f.session.Power.PCloudStorageCapacity.PcloudStoragecapacityTypesGet(params, f.session.AuthInfo(f.cloudInstanceID))
+
+	// Create params and send request
+	params := &params.PcloudStoragecapacityTypesGetParams{
+		CloudInstanceID: f.cloudInstanceID,
+		Context:         f.context,
+		StorageTypeName: storageType,
+	}
+	//params.SetTimeout(helpers.PIGetTimeOut)
+	resp, err := f.request.PcloudStoragecapacityTypesGet(params, f.auth)
+
+	// Handle errors
 	if err != nil {
 		return nil, fmt.Errorf("failed to get the capacity for storage type %s: %w", storageType, err)
 	}
@@ -67,12 +93,18 @@ func (f *IBMPIStorageCapacityClient) GetStorageTypeCapacity(storageType string) 
 	return resp.Payload, nil
 }
 
-// Storage capacity for all available storage types in a region
+// Get Storage Capacity for all available Storage Types in a Region
 func (f *IBMPIStorageCapacityClient) GetAllStorageTypesCapacity() (*models.StorageTypesCapacity, error) {
-	params := p_cloud_storage_capacity.NewPcloudStoragecapacityTypesGetallParams().
-		WithContext(f.ctx).WithTimeout(helpers.PIGetTimeOut).
-		WithCloudInstanceID(f.cloudInstanceID)
-	resp, err := f.session.Power.PCloudStorageCapacity.PcloudStoragecapacityTypesGetall(params, f.session.AuthInfo(f.cloudInstanceID))
+
+	// Create params and send request
+	params := &params.PcloudStoragecapacityTypesGetallParams{
+		CloudInstanceID: f.cloudInstanceID,
+		Context:         f.context,
+	}
+	//params.SetTimeout(helpers.PIGetTimeOut)
+	resp, err := f.request.PcloudStoragecapacityTypesGetall(params, f.auth)
+
+	// Handle errors
 	if err != nil {
 		return nil, fmt.Errorf("failed to get the capacity for all storage types %w", err)
 	}


### PR DESCRIPTION
- Create Params with structs instead of a function
- Use default service broker timeout (previous timeout is commented out)
- Eliminated need for `IBMPIClient` and `ibm_pi_helper.go`
  - I plan on removing these in a different PR