### PR TITLE
Cleaned up Snapshot

### DIFF
--- a/clients/instance/ibm-pi-snapshot.go
+++ b/clients/instance/ibm-pi-snapshot.go
@@ -4,74 +4,109 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/IBM-Cloud/power-go-client/helpers"
 	"github.com/IBM-Cloud/power-go-client/ibmpisession"
-	"github.com/IBM-Cloud/power-go-client/power/client/p_cloud_p_vm_instances"
-	"github.com/IBM-Cloud/power-go-client/power/client/p_cloud_snapshots"
+	instanceParams "github.com/IBM-Cloud/power-go-client/power/client/p_cloud_p_vm_instances"
+	snapshotParams "github.com/IBM-Cloud/power-go-client/power/client/p_cloud_snapshots"
 	"github.com/IBM-Cloud/power-go-client/power/models"
+	"github.com/go-openapi/runtime"
 )
 
 // IBMPISnapshotClient ...
 type IBMPISnapshotClient struct {
-	IBMPIClient
+	auth            runtime.ClientAuthInfoWriter
+	cloudInstanceID string
+	context         context.Context
+	instanceRequest instanceParams.ClientService
+	snapshotRequest snapshotParams.ClientService
 }
 
 // NewIBMPISnapshotClient ...
 func NewIBMPISnapshotClient(ctx context.Context, sess *ibmpisession.IBMPISession, cloudInstanceID string) *IBMPISnapshotClient {
 	return &IBMPISnapshotClient{
-		*NewIBMPIClient(ctx, sess, cloudInstanceID),
+		auth:            sess.AuthInfo(cloudInstanceID),
+		cloudInstanceID: cloudInstanceID,
+		context:         ctx,
+		instanceRequest: sess.Power.PCloudpVMInstances,
+		snapshotRequest: sess.Power.PCloudSnapshots,
 	}
 }
 
-//Get information about a single snapshot only
-func (f *IBMPISnapshotClient) Get(id string) (*models.Snapshot, error) {
-	params := p_cloud_snapshots.NewPcloudCloudinstancesSnapshotsGetParams().
-		WithContext(f.ctx).WithTimeout(helpers.PIGetTimeOut).
-		WithCloudInstanceID(f.cloudInstanceID).WithSnapshotID(id)
-	resp, err := f.session.Power.PCloudSnapshots.PcloudCloudinstancesSnapshotsGet(params, f.session.AuthInfo(f.cloudInstanceID))
+// Get a Snapshot
+func (f *IBMPISnapshotClient) Get(snapshotID string) (*models.Snapshot, error) {
+
+	// Create params and send request
+	params := &snapshotParams.PcloudCloudinstancesSnapshotsGetParams{
+		CloudInstanceID: f.cloudInstanceID,
+		Context:         f.context,
+		SnapshotID:      snapshotID,
+	}
+	//params.SetTimeout(helpers.PIGetTimeOut)
+	resp, err := f.snapshotRequest.PcloudCloudinstancesSnapshotsGet(params, f.auth)
+
+	// Handle errors
 	if err != nil {
-		return nil, fmt.Errorf("failed to Get PI Snapshot %s: %w", id, err)
+		return nil, fmt.Errorf("failed to Get PI Snapshot %s: %w", snapshotID, err)
 	}
 	if resp == nil || resp.Payload == nil {
-		return nil, fmt.Errorf("failed to Get PI Snapshot %s", id)
+		return nil, fmt.Errorf("failed to Get PI Snapshot %s", snapshotID)
 	}
 	return resp.Payload, nil
 }
 
-// Delete ...
-func (f *IBMPISnapshotClient) Delete(id string) error {
-	params := p_cloud_snapshots.NewPcloudCloudinstancesSnapshotsDeleteParams().
-		WithContext(f.ctx).WithTimeout(helpers.PIDeleteTimeOut).
-		WithCloudInstanceID(f.cloudInstanceID).WithSnapshotID(id)
-	_, err := f.session.Power.PCloudSnapshots.PcloudCloudinstancesSnapshotsDelete(params, f.session.AuthInfo(f.cloudInstanceID))
+// Delete a Snapshot
+func (f *IBMPISnapshotClient) Delete(snapshotID string) error {
+
+	// Create params and send request
+	params := &snapshotParams.PcloudCloudinstancesSnapshotsDeleteParams{
+		CloudInstanceID: f.cloudInstanceID,
+		Context:         f.context,
+		SnapshotID:      snapshotID,
+	}
+	//params.SetTimeout(helpers.PIDeleteTimeOut)
+	_, err := f.snapshotRequest.PcloudCloudinstancesSnapshotsDelete(params, f.auth)
+
+	// Handle errors
 	if err != nil {
-		return fmt.Errorf("failed to Delete PI Snapshot %s: %w", id, err)
+		return fmt.Errorf("failed to Delete PI Snapshot %s: %w", snapshotID, err)
 	}
 	return nil
 }
 
-// Update ...
-func (f *IBMPISnapshotClient) Update(id string, body *models.SnapshotUpdate) (models.Object, error) {
-	params := p_cloud_snapshots.NewPcloudCloudinstancesSnapshotsPutParams().
-		WithContext(f.ctx).WithTimeout(helpers.PIUpdateTimeOut).
-		WithCloudInstanceID(f.cloudInstanceID).WithSnapshotID(id).
-		WithBody(body)
-	resp, err := f.session.Power.PCloudSnapshots.PcloudCloudinstancesSnapshotsPut(params, f.session.AuthInfo(f.cloudInstanceID))
+// Update a Snapshot
+func (f *IBMPISnapshotClient) Update(snapshotID string, updateBody *models.SnapshotUpdate) (models.Object, error) {
+
+	// Create params and send request
+	params := &snapshotParams.PcloudCloudinstancesSnapshotsPutParams{
+		Body:            updateBody,
+		CloudInstanceID: f.cloudInstanceID,
+		Context:         f.context,
+		SnapshotID:      snapshotID,
+	}
+	//params.SetTimeout(helpers.PIUpdateTimeOut)
+	resp, err := f.snapshotRequest.PcloudCloudinstancesSnapshotsPut(params, f.auth)
+
+	// Handle errors
 	if err != nil {
-		return nil, fmt.Errorf("failed to Update PI Snapshot %s: %w", id, err)
+		return nil, fmt.Errorf("failed to Update PI Snapshot %s: %w", snapshotID, err)
 	}
 	if resp == nil || resp.Payload == nil {
-		return nil, fmt.Errorf("failed to Update PI Snapshot %s", id)
+		return nil, fmt.Errorf("failed to Update PI Snapshot %s", snapshotID)
 	}
 	return resp.Payload, nil
 }
 
-// GetAll snapshots
+// Get All Snapshots
 func (f *IBMPISnapshotClient) GetAll() (*models.Snapshots, error) {
-	params := p_cloud_snapshots.NewPcloudCloudinstancesSnapshotsGetallParams().
-		WithContext(f.ctx).WithTimeout(helpers.PIGetTimeOut).
-		WithCloudInstanceID(f.cloudInstanceID)
-	resp, err := f.session.Power.PCloudSnapshots.PcloudCloudinstancesSnapshotsGetall(params, f.session.AuthInfo(f.cloudInstanceID))
+
+	// Create params and send request
+	params := &snapshotParams.PcloudCloudinstancesSnapshotsGetallParams{
+		CloudInstanceID: f.cloudInstanceID,
+		Context:         f.context,
+	}
+	//params.SetTimeout(helpers.PIGetTimeOut)
+	resp, err := f.snapshotRequest.PcloudCloudinstancesSnapshotsGetall(params, f.auth)
+
+	// Handle errors
 	if err != nil {
 		return nil, fmt.Errorf("failed to Get all PI Snapshots: %w", err)
 	}
@@ -83,11 +118,19 @@ func (f *IBMPISnapshotClient) GetAll() (*models.Snapshots, error) {
 
 // Create or Restore a Snapshot
 func (f *IBMPISnapshotClient) Create(instanceID, snapshotID, restoreFailAction string) (*models.Snapshot, error) {
-	params := p_cloud_p_vm_instances.NewPcloudPvminstancesSnapshotsRestorePostParams().
-		WithContext(f.ctx).WithTimeout(helpers.PICreateTimeOut).
-		WithCloudInstanceID(f.cloudInstanceID).WithPvmInstanceID(instanceID).
-		WithSnapshotID(snapshotID).WithRestoreFailAction(&restoreFailAction)
-	resp, err := f.session.Power.PCloudpVMInstances.PcloudPvminstancesSnapshotsRestorePost(params, f.session.AuthInfo(f.cloudInstanceID))
+
+	// Create params and send request
+	params := &instanceParams.PcloudPvminstancesSnapshotsRestorePostParams{
+		CloudInstanceID:   f.cloudInstanceID,
+		Context:           f.context,
+		PvmInstanceID:     instanceID,
+		RestoreFailAction: &restoreFailAction,
+		SnapshotID:        snapshotID,
+	}
+	//params.SetTimeout(helpers.PICreateTimeOut)
+	resp, err := f.instanceRequest.PcloudPvminstancesSnapshotsRestorePost(params, f.auth)
+
+	// Handle errors
 	if err != nil {
 		return nil, fmt.Errorf("failed to restore PI Snapshot %s of the instance %s: %w", snapshotID, instanceID, err)
 	}


### PR DESCRIPTION
- Create Params with structs instead of a function
- Use default service broker timeout (previous timeout is commented out)
- Eliminated need for `IBMPIClient` and `ibm_pi_helper.go`
  - I plan on removing these in a different PR