### PR TITLE
Cleaned up Placement Groups

### DIFF
--- a/clients/instance/ibm-pi-placement-groups.go
+++ b/clients/instance/ibm-pi-placement-groups.go
@@ -5,46 +5,64 @@ import (
 	"fmt"
 
 	"github.com/IBM-Cloud/power-go-client/errors"
-	"github.com/IBM-Cloud/power-go-client/power/client/p_cloud_placement_groups"
-
-	"github.com/IBM-Cloud/power-go-client/helpers"
 	"github.com/IBM-Cloud/power-go-client/ibmpisession"
+	params "github.com/IBM-Cloud/power-go-client/power/client/p_cloud_placement_groups"
 	"github.com/IBM-Cloud/power-go-client/power/models"
+	"github.com/go-openapi/runtime"
 )
 
 //IBMPIPlacementGroupClient ...
 type IBMPIPlacementGroupClient struct {
-	IBMPIClient
+	auth            runtime.ClientAuthInfoWriter
+	cloudInstanceID string
+	context         context.Context
+	request         params.ClientService
 }
 
 // NewIBMPIPlacementGroupClient ...
 func NewIBMPIPlacementGroupClient(ctx context.Context, sess *ibmpisession.IBMPISession, cloudInstanceID string) *IBMPIPlacementGroupClient {
 	return &IBMPIPlacementGroupClient{
-		*NewIBMPIClient(ctx, sess, cloudInstanceID),
+		auth:            sess.AuthInfo(cloudInstanceID),
+		cloudInstanceID: cloudInstanceID,
+		context:         ctx,
+		request:         sess.Power.PCloudPlacementGroups,
 	}
 }
 
-// Get PI Placementgroup
-func (f *IBMPIPlacementGroupClient) Get(id string) (*models.PlacementGroup, error) {
-	params := p_cloud_placement_groups.NewPcloudPlacementgroupsGetParams().
-		WithContext(f.ctx).WithTimeout(helpers.PIGetTimeOut).
-		WithCloudInstanceID(f.cloudInstanceID).WithPlacementGroupID(id)
-	resp, err := f.session.Power.PCloudPlacementGroups.PcloudPlacementgroupsGet(params, f.session.AuthInfo(f.cloudInstanceID))
+// Get a Placement Group
+func (f *IBMPIPlacementGroupClient) Get(placementGroupID string) (*models.PlacementGroup, error) {
+
+	// Create params and send request
+	params := &params.PcloudPlacementgroupsGetParams{
+		CloudInstanceID:  f.cloudInstanceID,
+		Context:          f.context,
+		PlacementGroupID: placementGroupID,
+	}
+	//params.SetTimeout(helpers.PIGetTimeOut)
+	resp, err := f.request.PcloudPlacementgroupsGet(params, f.auth)
+
+	// Handle errors
 	if err != nil {
-		return nil, fmt.Errorf(errors.GetPlacementGroupOperationFailed, id, err)
+		return nil, fmt.Errorf(errors.GetPlacementGroupOperationFailed, placementGroupID, err)
 	}
 	if resp == nil || resp.Payload == nil {
-		return nil, fmt.Errorf("failed to Get Placement Group %s", id)
+		return nil, fmt.Errorf("failed to Get Placement Group %s", placementGroupID)
 	}
 	return resp.Payload, nil
 }
 
-// Get All placement groups
+// Get All Placement Groups
 func (f *IBMPIPlacementGroupClient) GetAll() (*models.PlacementGroups, error) {
-	params := p_cloud_placement_groups.NewPcloudPlacementgroupsGetallParams().
-		WithContext(f.ctx).WithTimeout(helpers.PIGetTimeOut).
-		WithCloudInstanceID(f.cloudInstanceID)
-	resp, err := f.session.Power.PCloudPlacementGroups.PcloudPlacementgroupsGetall(params, f.session.AuthInfo(f.cloudInstanceID))
+
+	// Create params and send request
+	params := &params.PcloudPlacementgroupsGetallParams{
+		CloudInstanceID: f.cloudInstanceID,
+		Context:         f.context,
+	}
+	//params.SetTimeout(helpers.PIGetTimeOut)
+	resp, err := f.request.PcloudPlacementgroupsGetall(params, f.auth)
+
+	// Handle errors
 	if err != nil {
 		return nil, fmt.Errorf("failed to Get All Placement Groups: %w", err)
 	}
@@ -54,61 +72,89 @@ func (f *IBMPIPlacementGroupClient) GetAll() (*models.PlacementGroups, error) {
 	return resp.Payload, nil
 }
 
-// Create the placement group
-func (f *IBMPIPlacementGroupClient) Create(body *models.PlacementGroupCreate) (*models.PlacementGroup, error) {
-	params := p_cloud_placement_groups.NewPcloudPlacementgroupsPostParams().
-		WithContext(f.ctx).WithTimeout(helpers.PICreateTimeOut).
-		WithCloudInstanceID(f.cloudInstanceID).WithBody(body)
-	postok, err := f.session.Power.PCloudPlacementGroups.PcloudPlacementgroupsPost(params, f.session.AuthInfo(f.cloudInstanceID))
+// Create a Placement Group
+func (f *IBMPIPlacementGroupClient) Create(createBody *models.PlacementGroupCreate) (*models.PlacementGroup, error) {
+
+	// Create params and send request
+	params := &params.PcloudPlacementgroupsPostParams{
+		Body:            createBody,
+		CloudInstanceID: f.cloudInstanceID,
+		Context:         f.context,
+	}
+	//params.SetTimeout(helpers.PICreateTimeOut)
+	resp, err := f.request.PcloudPlacementgroupsPost(params, f.auth)
+
+	// Handle errors
 	if err != nil {
 		return nil, fmt.Errorf(errors.CreatePlacementGroupOperationFailed, f.cloudInstanceID, err)
 	}
-	if postok == nil || postok.Payload == nil {
+	if resp == nil || resp.Payload == nil {
 		return nil, fmt.Errorf("failed to Create Placement Group")
 	}
-	return postok.Payload, nil
+	return resp.Payload, nil
 }
 
-// Delete Placement Group
-func (f *IBMPIPlacementGroupClient) Delete(id string) error {
-	params := p_cloud_placement_groups.NewPcloudPlacementgroupsDeleteParams().
-		WithContext(f.ctx).WithTimeout(helpers.PIDeleteTimeOut).
-		WithCloudInstanceID(f.cloudInstanceID).WithPlacementGroupID(id)
-	_, err := f.session.Power.PCloudPlacementGroups.PcloudPlacementgroupsDelete(params, f.session.AuthInfo(f.cloudInstanceID))
+// Delete a Placement Group
+func (f *IBMPIPlacementGroupClient) Delete(placementGroupID string) error {
+
+	// Create params and send request
+	params := &params.PcloudPlacementgroupsDeleteParams{
+		CloudInstanceID:  f.cloudInstanceID,
+		Context:          f.context,
+		PlacementGroupID: placementGroupID,
+	}
+	//params.SetTimeout(helpers.PIDeleteTimeOut)
+	_, err := f.request.PcloudPlacementgroupsDelete(params, f.auth)
+
+	// Handle errors
 	if err != nil {
-		return fmt.Errorf(errors.DeletePlacementGroupOperationFailed, id, err)
+		return fmt.Errorf(errors.DeletePlacementGroupOperationFailed, placementGroupID, err)
 	}
 	return nil
 }
 
-// Adding a member to a  Placement Group
-func (f *IBMPIPlacementGroupClient) AddMember(id string, body *models.PlacementGroupServer) (*models.PlacementGroup, error) {
-	params := p_cloud_placement_groups.NewPcloudPlacementgroupsMembersPostParams().
-		WithContext(f.ctx).WithTimeout(helpers.PICreateTimeOut).
-		WithCloudInstanceID(f.cloudInstanceID).WithPlacementGroupID(id).
-		WithBody(body)
-	postok, err := f.session.Power.PCloudPlacementGroups.PcloudPlacementgroupsMembersPost(params, f.session.AuthInfo(f.cloudInstanceID))
+// Add a Member to a Placement Group
+func (f *IBMPIPlacementGroupClient) AddMember(placementGroupID string, udpateBody *models.PlacementGroupServer) (*models.PlacementGroup, error) {
+
+	// Create params and send request
+	params := &params.PcloudPlacementgroupsMembersPostParams{
+		Body:             udpateBody,
+		CloudInstanceID:  f.cloudInstanceID,
+		Context:          f.context,
+		PlacementGroupID: placementGroupID,
+	}
+	//params.SetTimeout(helpers.PICreateTimeOut)
+	resp, err := f.request.PcloudPlacementgroupsMembersPost(params, f.auth)
+
+	// Handle errors
 	if err != nil {
-		return nil, fmt.Errorf(errors.AddMemberPlacementGroupOperationFailed, *body.ID, id, err)
+		return nil, fmt.Errorf(errors.AddMemberPlacementGroupOperationFailed, *udpateBody.ID, placementGroupID, err)
 	}
-	if postok == nil || postok.Payload == nil {
-		return nil, fmt.Errorf("failed to Add Member for instance %s and placement group %s", *body.ID, id)
+	if resp == nil || resp.Payload == nil {
+		return nil, fmt.Errorf("failed to Add Member for instance %s and placement group %s", *udpateBody.ID, placementGroupID)
 	}
-	return postok.Payload, nil
+	return resp.Payload, nil
 }
 
-// Delete Member from Placement Group
-func (f *IBMPIPlacementGroupClient) DeleteMember(id string, body *models.PlacementGroupServer) (*models.PlacementGroup, error) {
-	params := p_cloud_placement_groups.NewPcloudPlacementgroupsMembersDeleteParams().
-		WithContext(f.ctx).WithTimeout(helpers.PIDeleteTimeOut).
-		WithCloudInstanceID(f.cloudInstanceID).WithPlacementGroupID(id).
-		WithBody(body)
-	delok, err := f.session.Power.PCloudPlacementGroups.PcloudPlacementgroupsMembersDelete(params, f.session.AuthInfo(f.cloudInstanceID))
+// Delete a Member from Placement Group
+func (f *IBMPIPlacementGroupClient) DeleteMember(placementGroupID string, udpateBody *models.PlacementGroupServer) (*models.PlacementGroup, error) {
+
+	// Create params and send request
+	params := &params.PcloudPlacementgroupsMembersDeleteParams{
+		Body:             udpateBody,
+		CloudInstanceID:  f.cloudInstanceID,
+		Context:          f.context,
+		PlacementGroupID: placementGroupID,
+	}
+	//params.SetTimeout(helpers.PIDeleteTimeOut)
+	resp, err := f.request.PcloudPlacementgroupsMembersDelete(params, f.auth)
+
+	// Handle errors
 	if err != nil {
-		return nil, fmt.Errorf(errors.DeleteMemberPlacementGroupOperationFailed, *body.ID, id, err)
+		return nil, fmt.Errorf(errors.DeleteMemberPlacementGroupOperationFailed, *udpateBody.ID, placementGroupID, err)
 	}
-	if delok == nil || delok.Payload == nil {
-		return nil, fmt.Errorf("failed to Delete Member for instance %s and placement group %s", *body.ID, id)
+	if resp == nil || resp.Payload == nil {
+		return nil, fmt.Errorf("failed to Delete Member for instance %s and placement group %s", *udpateBody.ID, placementGroupID)
 	}
-	return delok.Payload, nil
+	return resp.Payload, nil
 }


### PR DESCRIPTION
- Create Params with structs instead of a function
- Use default service broker timeout (previous timeout is commented out)
- Eliminated need for `IBMPIClient` and `ibm_pi_helper.go`
  - I plan on removing these in a different PR