### PR TITLE
Cleaned up Network

### DIFF
--- a/clients/instance/ibm-pi-network.go
+++ b/clients/instance/ibm-pi-network.go
@@ -5,46 +5,64 @@ import (
 	"fmt"
 
 	"github.com/IBM-Cloud/power-go-client/errors"
-	"github.com/IBM-Cloud/power-go-client/helpers"
-
 	"github.com/IBM-Cloud/power-go-client/ibmpisession"
-	"github.com/IBM-Cloud/power-go-client/power/client/p_cloud_networks"
+	params "github.com/IBM-Cloud/power-go-client/power/client/p_cloud_networks"
 	"github.com/IBM-Cloud/power-go-client/power/models"
+	"github.com/go-openapi/runtime"
 )
 
 // IBMPINetworkClient ...
 type IBMPINetworkClient struct {
-	IBMPIClient
+	auth            runtime.ClientAuthInfoWriter
+	cloudInstanceID string
+	context         context.Context
+	request         params.ClientService
 }
 
 // NewIBMPINetworkClient ...
 func NewIBMPINetworkClient(ctx context.Context, sess *ibmpisession.IBMPISession, cloudInstanceID string) *IBMPINetworkClient {
 	return &IBMPINetworkClient{
-		*NewIBMPIClient(ctx, sess, cloudInstanceID),
+		auth:            sess.AuthInfo(cloudInstanceID),
+		cloudInstanceID: cloudInstanceID,
+		context:         ctx,
+		request:         sess.Power.PCloudNetworks,
 	}
 }
 
-// Get ...
-func (f *IBMPINetworkClient) Get(id string) (*models.Network, error) {
-	params := p_cloud_networks.NewPcloudNetworksGetParams().
-		WithContext(f.ctx).WithTimeout(helpers.PIGetTimeOut).
-		WithCloudInstanceID(f.cloudInstanceID).WithNetworkID(id)
-	resp, err := f.session.Power.PCloudNetworks.PcloudNetworksGet(params, f.session.AuthInfo(f.cloudInstanceID))
+// Get a Network
+func (f *IBMPINetworkClient) Get(networkID string) (*models.Network, error) {
+
+	// Create params and send request
+	params := &params.PcloudNetworksGetParams{
+		CloudInstanceID: f.cloudInstanceID,
+		Context:         f.context,
+		NetworkID:       networkID,
+	}
+	//params.SetTimeout(helpers.PIGetTimeOut)
+	resp, err := f.request.PcloudNetworksGet(params, f.auth)
+
+	// Handle errors
 	if err != nil {
-		return nil, fmt.Errorf(errors.GetNetworkOperationFailed, id, err)
+		return nil, fmt.Errorf(errors.GetNetworkOperationFailed, networkID, err)
 	}
 	if resp == nil || resp.Payload == nil {
-		return nil, fmt.Errorf("failed to Get Network %s", id)
+		return nil, fmt.Errorf("failed to Get Network %s", networkID)
 	}
 	return resp.Payload, nil
 }
 
-// Get All
+// Get All Networks
 func (f *IBMPINetworkClient) GetAll() (*models.Networks, error) {
-	params := p_cloud_networks.NewPcloudNetworksGetallParams().
-		WithContext(f.ctx).WithTimeout(helpers.PIGetTimeOut).
-		WithCloudInstanceID(f.cloudInstanceID)
-	resp, err := f.session.Power.PCloudNetworks.PcloudNetworksGetall(params, f.session.AuthInfo(f.cloudInstanceID))
+
+	// Create params and send request
+	params := &params.PcloudNetworksGetallParams{
+		CloudInstanceID: f.cloudInstanceID,
+		Context:         f.context,
+	}
+	//params.SetTimeout(helpers.PIGetTimeOut)
+	resp, err := f.request.PcloudNetworksGetall(params, f.auth)
+
+	// Handle errors
 	if err != nil {
 		return nil, fmt.Errorf("failed to Get Network for cloud instance %s with error %w", f.cloudInstanceID, err)
 	}
@@ -54,47 +72,67 @@ func (f *IBMPINetworkClient) GetAll() (*models.Networks, error) {
 	return resp.Payload, nil
 }
 
-// Create ...
-func (f *IBMPINetworkClient) Create(body *models.NetworkCreate) (*models.Network, error) {
-	params := p_cloud_networks.NewPcloudNetworksPostParams().
-		WithContext(f.ctx).WithTimeout(helpers.PICreateTimeOut).
-		WithCloudInstanceID(f.cloudInstanceID).WithBody(body)
-	postok, postcreated, err := f.session.Power.PCloudNetworks.PcloudNetworksPost(params, f.session.AuthInfo(f.cloudInstanceID))
+// Create a Network
+func (f *IBMPINetworkClient) Create(createBody *models.NetworkCreate) (*models.Network, error) {
+
+	// Create params and send request
+	params := &params.PcloudNetworksPostParams{
+		CloudInstanceID: f.cloudInstanceID,
+		Context:         f.context,
+		Body:            createBody,
+	}
+	//params.SetTimeout(helpers.PICreateTimeOut)
+	respOk, respCreated, err := f.request.PcloudNetworksPost(params, f.auth)
+
+	// Handle errors
 	if err != nil {
-		return nil, fmt.Errorf(errors.CreateNetworkOperationFailed, body.Name, err)
 	}
-	if postok != nil && postok.Payload != nil {
-		return postok.Payload, nil
+	if respOk != nil && respOk.Payload != nil {
+		return respOk.Payload, nil
 	}
-	if postcreated != nil && postcreated.Payload != nil {
-		return postcreated.Payload, nil
+	if respCreated != nil && respCreated.Payload != nil {
+		return respCreated.Payload, nil
 	}
-	return nil, fmt.Errorf("failed to perform Create Network Operation for Network %s", body.Name)
+	return nil, fmt.Errorf("failed to perform Create Network Operation for Network %s", createBody.Name)
 }
 
-// Update ...
-func (f *IBMPINetworkClient) Update(id string, body *models.NetworkUpdate) (*models.Network, error) {
-	params := p_cloud_networks.NewPcloudNetworksPutParams().
-		WithContext(f.ctx).WithTimeout(helpers.PIUpdateTimeOut).
-		WithCloudInstanceID(f.cloudInstanceID).WithNetworkID(id).
-		WithBody(body)
-	resp, err := f.session.Power.PCloudNetworks.PcloudNetworksPut(params, f.session.AuthInfo(f.cloudInstanceID))
+// Update a Network
+func (f *IBMPINetworkClient) Update(networkID string, updateBody *models.NetworkUpdate) (*models.Network, error) {
+
+	// Create params and send request
+	params := &params.PcloudNetworksPutParams{
+		CloudInstanceID: f.cloudInstanceID,
+		Body:            updateBody,
+		Context:         f.context,
+		NetworkID:       networkID,
+	}
+	//params.SetTimeout(helpers.PIUpdateTimeOut)
+	resp, err := f.request.PcloudNetworksPut(params, f.auth)
+
+	// Handle errors
 	if err != nil {
-		return nil, fmt.Errorf("failed to perform Update Network Operation for Network %s with error %w", id, err)
+		return nil, fmt.Errorf("failed to perform Update Network Operation for Network %s with error %w", networkID, err)
 	}
 	if resp == nil || resp.Payload == nil {
-		return nil, fmt.Errorf("failed to perform Update Network Operation for Network %s", id)
+		return nil, fmt.Errorf("failed to perform Update Network Operation for Network %s", networkID)
 	}
 	return resp.Payload, nil
 }
 
-// GetPublic ...
+// Get All Public Networks
 func (f *IBMPINetworkClient) GetAllPublic() (*models.Networks, error) {
+
+	// Create params and send request
 	filterQuery := "type=\"pub-vlan\""
-	params := p_cloud_networks.NewPcloudNetworksGetallParams().
-		WithContext(f.ctx).WithTimeout(helpers.PIGetTimeOut).
-		WithCloudInstanceID(f.cloudInstanceID).WithFilter(&filterQuery)
-	resp, err := f.session.Power.PCloudNetworks.PcloudNetworksGetall(params, f.session.AuthInfo(f.cloudInstanceID))
+	params := &params.PcloudNetworksGetallParams{
+		CloudInstanceID: f.cloudInstanceID,
+		Context:         f.context,
+		Filter:          &filterQuery,
+	}
+	//params.SetTimeout(helpers.PIGetTimeOut)
+	resp, err := f.request.PcloudNetworksGetall(params, f.auth)
+
+	// Handle errors
 	if err != nil {
 		return nil, fmt.Errorf("failed to Get all Public Networks for cloud instance %s: %w", f.cloudInstanceID, err)
 	}
@@ -104,91 +142,133 @@ func (f *IBMPINetworkClient) GetAllPublic() (*models.Networks, error) {
 	return resp.Payload, nil
 }
 
-// Delete ...
-func (f *IBMPINetworkClient) Delete(id string) error {
-	params := p_cloud_networks.NewPcloudNetworksDeleteParams().
-		WithContext(f.ctx).WithTimeout(helpers.PIDeleteTimeOut).
-		WithCloudInstanceID(f.cloudInstanceID).WithNetworkID(id)
-	_, err := f.session.Power.PCloudNetworks.PcloudNetworksDelete(params, f.session.AuthInfo(f.cloudInstanceID))
+// Delete a Network
+func (f *IBMPINetworkClient) Delete(networkID string) error {
+
+	// Create params and send request
+	params := &params.PcloudNetworksDeleteParams{
+		CloudInstanceID: f.cloudInstanceID,
+		Context:         f.context,
+		NetworkID:       networkID,
+	}
+	//params.SetTimeout(helpers.PIDeleteTimeOut)
+	_, err := f.request.PcloudNetworksDelete(params, f.auth)
+
+	// Handle errors
 	if err != nil {
-		return fmt.Errorf("failed to Delete PI Network %s: %w", id, err)
+		return fmt.Errorf("failed to Delete PI Network %s: %w", networkID, err)
 	}
 	return nil
 }
 
-//GetAllPorts ...
-func (f *IBMPINetworkClient) GetAllPorts(id string) (*models.NetworkPorts, error) {
-	params := p_cloud_networks.NewPcloudNetworksPortsGetallParams().
-		WithContext(f.ctx).WithTimeout(helpers.PIGetTimeOut).
-		WithCloudInstanceID(f.cloudInstanceID).WithNetworkID(id)
-	resp, err := f.session.Power.PCloudNetworks.PcloudNetworksPortsGetall(params, f.session.AuthInfo(f.cloudInstanceID))
+// Get All Ports on a Network
+func (f *IBMPINetworkClient) GetAllPorts(networkID string) (*models.NetworkPorts, error) {
+
+	// Create params and send request
+	params := &params.PcloudNetworksPortsGetallParams{
+		CloudInstanceID: f.cloudInstanceID,
+		Context:         f.context,
+		NetworkID:       networkID,
+	}
+	//params.SetTimeout(helpers.PIGetTimeOut)
+	resp, err := f.request.PcloudNetworksPortsGetall(params, f.auth)
+
+	// Handle errors
 	if err != nil {
-		return nil, fmt.Errorf("failed to Get all Network Ports for Network %s: %w", id, err)
+		return nil, fmt.Errorf("failed to Get all Network Ports for Network %s: %w", networkID, err)
 	}
 	if resp == nil || resp.Payload == nil {
-		return nil, fmt.Errorf("failed to Get all Network Ports for Network %s", id)
+		return nil, fmt.Errorf("failed to Get all Network Ports for Network %s", networkID)
 	}
 	return resp.Payload, nil
 }
 
-// GetPort ...
-func (f *IBMPINetworkClient) GetPort(id string, networkPortID string) (*models.NetworkPort, error) {
-	params := p_cloud_networks.NewPcloudNetworksPortsGetParams().
-		WithContext(f.ctx).WithTimeout(helpers.PIGetTimeOut).
-		WithCloudInstanceID(f.cloudInstanceID).WithNetworkID(id).
-		WithPortID(networkPortID)
-	resp, err := f.session.Power.PCloudNetworks.PcloudNetworksPortsGet(params, f.session.AuthInfo(f.cloudInstanceID))
+// Get a Port on a Network
+func (f *IBMPINetworkClient) GetPort(networkID string, portID string) (*models.NetworkPort, error) {
 
+	// Create params and send request
+	params := &params.PcloudNetworksPortsGetParams{
+		CloudInstanceID: f.cloudInstanceID,
+		Context:         f.context,
+		NetworkID:       networkID,
+		PortID:          portID,
+	}
+	//params.SetTimeout(helpers.PIGetTimeOut)
+	resp, err := f.request.PcloudNetworksPortsGet(params, f.auth)
+
+	// Handle errors
 	if err != nil {
-		return nil, fmt.Errorf("failed to Get PI Network Port %s for Network %s: %w", networkPortID, id, err)
+		return nil, fmt.Errorf("failed to Get PI Network Port %s for Network %s: %w", portID, networkID, err)
 	}
 	if resp == nil || resp.Payload == nil {
-		return nil, fmt.Errorf("failed to Get PI Network Port %s for Network %s", networkPortID, id)
+		return nil, fmt.Errorf("failed to Get PI Network Port %s for Network %s", portID, networkID)
 	}
 	return resp.Payload, nil
 }
 
-// CreatePort ...
-func (f *IBMPINetworkClient) CreatePort(id string, body *models.NetworkPortCreate) (*models.NetworkPort, error) {
-	params := p_cloud_networks.NewPcloudNetworksPortsPostParams().
-		WithContext(f.ctx).WithTimeout(helpers.PICreateTimeOut).
-		WithCloudInstanceID(f.cloudInstanceID).WithNetworkID(id).
-		WithBody(body)
-	resp, err := f.session.Power.PCloudNetworks.PcloudNetworksPortsPost(params, f.session.AuthInfo(f.cloudInstanceID))
+// Create a Port on a Network
+func (f *IBMPINetworkClient) CreatePort(networkID string, portBody *models.NetworkPortCreate) (*models.NetworkPort, error) {
+
+	// Create params and send request
+	params := &params.PcloudNetworksPortsPostParams{
+		Body:            portBody,
+		CloudInstanceID: f.cloudInstanceID,
+		Context:         f.context,
+		NetworkID:       networkID,
+	}
+	// params.SetTimeout(helpers.PICreateTimeOu)
+	resp, err := f.request.PcloudNetworksPortsPost(params, f.auth)
+
+	// Handle errors
 	if err != nil {
-		return nil, fmt.Errorf(errors.CreateNetworkPortOperationFailed, id, err)
+		return nil, fmt.Errorf(errors.CreateNetworkPortOperationFailed, networkID, err)
 	}
 	if resp == nil || resp.Payload == nil {
-		return nil, fmt.Errorf("failed to perform Create Network Port Operation for Network %s", id)
+		return nil, fmt.Errorf("failed to perform Create Network Port Operation for Network %s", networkID)
 	}
 	return resp.Payload, nil
 }
 
-// DeletePort ...
-func (f *IBMPINetworkClient) DeletePort(id string, networkPortID string) error {
-	params := p_cloud_networks.NewPcloudNetworksPortsDeleteParams().
-		WithContext(f.ctx).WithTimeout(helpers.PIDeleteTimeOut).
-		WithCloudInstanceID(f.cloudInstanceID).WithNetworkID(id).
-		WithPortID(networkPortID)
-	_, err := f.session.Power.PCloudNetworks.PcloudNetworksPortsDelete(params, f.session.AuthInfo(f.cloudInstanceID))
+// Delete a Port on a Network
+func (f *IBMPINetworkClient) DeletePort(networkID string, portID string) error {
+
+	// Create params and send request
+	params := &params.PcloudNetworksPortsDeleteParams{
+		CloudInstanceID: f.cloudInstanceID,
+		Context:         f.context,
+		NetworkID:       networkID,
+		PortID:          portID,
+	}
+	//params.SetTimeout(helpers.PIDeleteTimeOut)
+	_, err := f.request.PcloudNetworksPortsDelete(params, f.auth)
+
+	// Handle errors
 	if err != nil {
-		return fmt.Errorf("failed to delete the network port %s for network %s with error %w", networkPortID, id, err)
+		return fmt.Errorf("failed to delete the network port %s for network %s with error %w", portID, networkID, err)
 	}
 	return nil
 }
 
-//UpdatePort with the PVM Instance
-func (f *IBMPINetworkClient) UpdatePort(id, networkPortID string, body *models.NetworkPortUpdate) (*models.NetworkPort, error) {
-	params := p_cloud_networks.NewPcloudNetworksPortsPutParams().
-		WithContext(f.ctx).WithTimeout(helpers.PIUpdateTimeOut).
-		WithCloudInstanceID(f.cloudInstanceID).WithNetworkID(id).
-		WithPortID(networkPortID).WithBody(body)
-	resp, err := f.session.Power.PCloudNetworks.PcloudNetworksPortsPut(params, f.session.AuthInfo(f.cloudInstanceID))
+// Update a Port on a Network
+func (f *IBMPINetworkClient) UpdatePort(networkID, portID string, body *models.NetworkPortUpdate) (*models.NetworkPort, error) {
+
+	// Create params and send request
+	params := &params.PcloudNetworksPortsPutParams{
+		Body:            body,
+		CloudInstanceID: f.cloudInstanceID,
+		NetworkID:       networkID,
+		PortID:          portID,
+		Context:         f.context,
+	}
+	//params.SetTimeout(helpers.PIUpdateTimeOut)
+	resp, err := f.request.PcloudNetworksPortsPut(params, f.auth)
+
+	// Handle errors
 	if err != nil {
-		return nil, fmt.Errorf("failed to update the port %s and Network %s with error %w", networkPortID, id, err)
+		return nil, fmt.Errorf("failed to update the port %s and Network %s with error %w", portID, networkID, err)
 	}
 	if resp == nil || resp.Payload == nil {
-		return nil, fmt.Errorf("failed to update the port %s and Network %s", networkPortID, id)
+		return nil, fmt.Errorf("failed to update the port %s and Network %s", portID, networkID)
 	}
 	return resp.Payload, nil
 }


### PR DESCRIPTION
- Create Params with structs instead of a function
- Use default service broker timeout (previous timeout is commented out)
- Eliminated need for `IBMPIClient` and `ibm_pi_helper.go`
  - I plan on removing these in a different PR