### PR TITLE
Cleaned up Key

### DIFF
--- a/clients/instance/ibm-pi-key.go
+++ b/clients/instance/ibm-pi-key.go
@@ -5,48 +5,64 @@ import (
 	"fmt"
 
 	"github.com/IBM-Cloud/power-go-client/errors"
-	"github.com/IBM-Cloud/power-go-client/helpers"
-
 	"github.com/IBM-Cloud/power-go-client/ibmpisession"
-	"github.com/IBM-Cloud/power-go-client/power/client/p_cloud_tenants_ssh_keys"
+	params "github.com/IBM-Cloud/power-go-client/power/client/p_cloud_tenants_ssh_keys"
 	"github.com/IBM-Cloud/power-go-client/power/models"
+	"github.com/go-openapi/runtime"
 )
 
 // IBMPIKeyClient ...
 type IBMPIKeyClient struct {
-	IBMPIClient
+	auth     runtime.ClientAuthInfoWriter
+	context  context.Context
+	request  params.ClientService
+	tenantID string
 }
 
 // NewIBMPIKeyClient ...
 func NewIBMPIKeyClient(ctx context.Context, sess *ibmpisession.IBMPISession, cloudInstanceID string) *IBMPIKeyClient {
 	return &IBMPIKeyClient{
-		*NewIBMPIClient(ctx, sess, cloudInstanceID),
+		auth:     sess.AuthInfo(cloudInstanceID),
+		context:  ctx,
+		request:  sess.Power.PCloudTenantsSSHKeys,
+		tenantID: sess.Options.UserAccount,
 	}
 }
 
-// Get Key...
-func (f *IBMPIKeyClient) Get(id string) (*models.SSHKey, error) {
-	var tenantid = f.session.Options.UserAccount
-	params := p_cloud_tenants_ssh_keys.NewPcloudTenantsSshkeysGetParams().
-		WithContext(f.ctx).WithTimeout(helpers.PIGetTimeOut).
-		WithTenantID(tenantid).WithSshkeyName(id)
-	resp, err := f.session.Power.PCloudTenantsSSHKeys.PcloudTenantsSshkeysGet(params, f.session.AuthInfo(f.cloudInstanceID))
+// Get a SSH Key
+func (f *IBMPIKeyClient) Get(keyName string) (*models.SSHKey, error) {
+
+	// Create params and send request
+	params := &params.PcloudTenantsSshkeysGetParams{
+		Context:    f.context,
+		SshkeyName: keyName,
+		TenantID:   f.tenantID,
+	}
+	//params.SetTimeout(helpers.PIGetTimeOut)
+	resp, err := f.request.PcloudTenantsSshkeysGet(params, f.auth)
+
+	// Handle errors
 	if err != nil {
-		return nil, fmt.Errorf(errors.GetPIKeyOperationFailed, id, err)
+		return nil, fmt.Errorf(errors.GetPIKeyOperationFailed, keyName, err)
 	}
 	if resp == nil || resp.Payload == nil {
-		return nil, fmt.Errorf("failed to Get PI Key %s", id)
+		return nil, fmt.Errorf("failed to Get PI Key %s", keyName)
 	}
 	return resp.Payload, nil
 }
 
-// GetAll Information about all the PVM Instances for a Client
+// Get All SSH Keys
 func (f *IBMPIKeyClient) GetAll() (*models.SSHKeys, error) {
-	var tenantid = f.session.Options.UserAccount
-	params := p_cloud_tenants_ssh_keys.NewPcloudTenantsSshkeysGetallParams().
-		WithContext(f.ctx).WithTimeout(helpers.PIGetTimeOut).
-		WithTenantID(tenantid)
-	resp, err := f.session.Power.PCloudTenantsSSHKeys.PcloudTenantsSshkeysGetall(params, f.session.AuthInfo(f.cloudInstanceID))
+
+	// Create params and send request
+	params := &params.PcloudTenantsSshkeysGetallParams{
+		Context:  f.context,
+		TenantID: f.tenantID,
+	}
+	//params.SetTimeout(helpers.PIGetTimeOut)
+	resp, err := f.request.PcloudTenantsSshkeysGetall(params, f.auth)
+
+	// Handle errors
 	if err != nil {
 		return nil, fmt.Errorf("failed to Get all PI Keys: %w", err)
 	}
@@ -56,34 +72,46 @@ func (f *IBMPIKeyClient) GetAll() (*models.SSHKeys, error) {
 	return resp.Payload, nil
 }
 
-// Create PI Key ...
-func (f *IBMPIKeyClient) Create(body *models.SSHKey) (*models.SSHKey, error) {
-	var tenantid = f.session.Options.UserAccount
-	params := p_cloud_tenants_ssh_keys.NewPcloudTenantsSshkeysPostParams().
-		WithContext(f.ctx).WithTimeout(helpers.PICreateTimeOut).
-		WithTenantID(tenantid).WithBody(body)
-	postok, postcreated, err := f.session.Power.PCloudTenantsSSHKeys.PcloudTenantsSshkeysPost(params, f.session.AuthInfo(f.cloudInstanceID))
+// Create a SSH Key
+func (f *IBMPIKeyClient) Create(keyBody *models.SSHKey) (*models.SSHKey, error) {
+
+	// Create params and send request
+	params := &params.PcloudTenantsSshkeysPostParams{
+		Body:     keyBody,
+		Context:  f.context,
+		TenantID: f.tenantID,
+	}
+	//params.SetTimeout(helpers.PICreateTimeOut)
+	respOk, respCreated, err := f.request.PcloudTenantsSshkeysPost(params, f.auth)
+
+	// Handle errors
 	if err != nil {
 		return nil, fmt.Errorf(errors.CreatePIKeyOperationFailed, err)
 	}
-	if postok != nil && postok.Payload != nil {
-		return postok.Payload, nil
+	if respOk != nil && respOk.Payload != nil {
+		return respOk.Payload, nil
 	}
-	if postcreated != nil && postcreated.Payload != nil {
-		return postcreated.Payload, nil
+	if respCreated != nil && respCreated.Payload != nil {
+		return respCreated.Payload, nil
 	}
 	return nil, fmt.Errorf("failed to Create PI Key")
 }
 
-// Delete ...
-func (f *IBMPIKeyClient) Delete(id string) error {
-	var tenantid = f.session.Options.UserAccount
-	params := p_cloud_tenants_ssh_keys.NewPcloudTenantsSshkeysDeleteParams().
-		WithContext(f.ctx).WithTimeout(helpers.PIDeleteTimeOut).
-		WithTenantID(tenantid).WithSshkeyName(id)
-	_, err := f.session.Power.PCloudTenantsSSHKeys.PcloudTenantsSshkeysDelete(params, f.session.AuthInfo(f.cloudInstanceID))
+// Delete a SSH Key
+func (f *IBMPIKeyClient) Delete(keyName string) error {
+
+	// Create params and send request
+	params := &params.PcloudTenantsSshkeysDeleteParams{
+		Context:    f.context,
+		SshkeyName: keyName,
+		TenantID:   f.tenantID,
+	}
+	//params.SetTimeout(helpers.PIDeleteTimeOut)
+	_, err := f.request.PcloudTenantsSshkeysDelete(params, f.auth)
+
+	// Handle errors
 	if err != nil {
-		return fmt.Errorf(errors.DeletePIKeyOperationFailed, id, err)
+		return fmt.Errorf(errors.DeletePIKeyOperationFailed, keyName, err)
 	}
 	return nil
 }


### PR DESCRIPTION
- Create Params with structs instead of a function
- Use default service broker timeout (previous timeout is commented out)
- Eliminated need for `IBMPIClient` and `ibm_pi_helper.go`
  - I plan on removing these in a different PR