### PR TITLE
Cleaned up Instance

### DIFF
--- a/clients/instance/ibm-pi-instance.go
+++ b/clients/instance/ibm-pi-instance.go
@@ -4,45 +4,64 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/IBM-Cloud/power-go-client/helpers"
 	"github.com/IBM-Cloud/power-go-client/ibmpisession"
-	"github.com/IBM-Cloud/power-go-client/power/client/p_cloud_p_vm_instances"
+	params "github.com/IBM-Cloud/power-go-client/power/client/p_cloud_p_vm_instances"
 	"github.com/IBM-Cloud/power-go-client/power/models"
+	"github.com/go-openapi/runtime"
 )
 
 // IBMPIInstanceClient ...
 type IBMPIInstanceClient struct {
-	IBMPIClient
+	auth            runtime.ClientAuthInfoWriter
+	cloudInstanceID string
+	context         context.Context
+	request         params.ClientService
 }
 
 // NewIBMPIInstanceClient ...
 func NewIBMPIInstanceClient(ctx context.Context, sess *ibmpisession.IBMPISession, cloudInstanceID string) *IBMPIInstanceClient {
 	return &IBMPIInstanceClient{
-		*NewIBMPIClient(ctx, sess, cloudInstanceID),
+		auth:            sess.AuthInfo(cloudInstanceID),
+		cloudInstanceID: cloudInstanceID,
+		context:         ctx,
+		request:         sess.Power.PCloudpVMInstances,
 	}
 }
 
-//Get information about a single pvm only
-func (f *IBMPIInstanceClient) Get(id string) (*models.PVMInstance, error) {
-	params := p_cloud_p_vm_instances.NewPcloudPvminstancesGetParams().
-		WithContext(f.ctx).WithTimeout(helpers.PIGetTimeOut).
-		WithCloudInstanceID(f.cloudInstanceID).WithPvmInstanceID(id)
-	resp, err := f.session.Power.PCloudpVMInstances.PcloudPvminstancesGet(params, f.session.AuthInfo(f.cloudInstanceID))
+// Get an Instance
+func (f *IBMPIInstanceClient) Get(instanceID string) (*models.PVMInstance, error) {
+
+	// Create params and send request
+	params := &params.PcloudPvminstancesGetParams{
+		CloudInstanceID: f.cloudInstanceID,
+		Context:         f.context,
+		PvmInstanceID:   instanceID,
+	}
+	//params.SetTimeout(helpers.PIGetTimeOut)
+	resp, err := f.request.PcloudPvminstancesGet(params, f.auth)
+
+	// Handle Errors
 	if err != nil {
-		return nil, fmt.Errorf("failed to Get PVM Instance %s :%w", id, err)
+		return nil, fmt.Errorf("failed to Get PVM Instance %s :%w", instanceID, err)
 	}
 	if resp == nil || resp.Payload == nil {
-		return nil, fmt.Errorf("failed to Get PVM Instance %s", id)
+		return nil, fmt.Errorf("failed to Get PVM Instance %s", instanceID)
 	}
 	return resp.Payload, nil
 }
 
-// GetAll Information about all the PVM Instances for a Client
+// Get All Instances
 func (f *IBMPIInstanceClient) GetAll() (*models.PVMInstances, error) {
-	params := p_cloud_p_vm_instances.NewPcloudPvminstancesGetallParams().
-		WithContext(f.ctx).WithTimeout(helpers.PIGetTimeOut).
-		WithCloudInstanceID(f.cloudInstanceID)
-	resp, err := f.session.Power.PCloudpVMInstances.PcloudPvminstancesGetall(params, f.session.AuthInfo(f.cloudInstanceID))
+
+	// Create params and send request
+	params := &params.PcloudPvminstancesGetallParams{
+		CloudInstanceID: f.cloudInstanceID,
+		Context:         f.context,
+	}
+	//params.SetTimeout(helpers.PIGetTimeOut)
+	resp, err := f.request.PcloudPvminstancesGetall(params, f.auth)
+
+	// Handle Errors
 	if err != nil {
 		return nil, fmt.Errorf("failed to Get all PVM Instances of Power Instance %s :%w", f.cloudInstanceID, err)
 	}
@@ -52,234 +71,341 @@ func (f *IBMPIInstanceClient) GetAll() (*models.PVMInstances, error) {
 	return resp.Payload, nil
 }
 
-//Create ...
-func (f *IBMPIInstanceClient) Create(body *models.PVMInstanceCreate) (*models.PVMInstanceList, error) {
-	params := p_cloud_p_vm_instances.NewPcloudPvminstancesPostParams().
-		WithContext(f.ctx).WithTimeout(helpers.PICreateTimeOut).
-		WithCloudInstanceID(f.cloudInstanceID).WithBody(body)
-	postok, postcreated, postAccepted, err := f.session.Power.PCloudpVMInstances.PcloudPvminstancesPost(params, f.session.AuthInfo(f.cloudInstanceID))
+// Create an Instance
+func (f *IBMPIInstanceClient) Create(createBody *models.PVMInstanceCreate) (*models.PVMInstanceList, error) {
+
+	// Create params and send request
+	params := &params.PcloudPvminstancesPostParams{
+		Body:            createBody,
+		CloudInstanceID: f.cloudInstanceID,
+		Context:         f.context,
+	}
+	//params.SetTimeout(helpers.PICreateTimeOut)
+	respOk, respCreated, respAccepted, err := f.request.PcloudPvminstancesPost(params, f.auth)
+
+	// Handle Errors
 	if err != nil {
 		return nil, fmt.Errorf("failed to Create PVM Instance :%w", err)
 	}
-	if postok != nil && len(postok.Payload) > 0 {
-		return &postok.Payload, nil
+	if respOk != nil && len(respOk.Payload) > 0 {
+		return &respOk.Payload, nil
 	}
-	if postcreated != nil && len(postcreated.Payload) > 0 {
-		return &postcreated.Payload, nil
+	if respCreated != nil && len(respCreated.Payload) > 0 {
+		return &respCreated.Payload, nil
 	}
-	if postAccepted != nil && len(postAccepted.Payload) > 0 {
-		return &postAccepted.Payload, nil
+	if respAccepted != nil && len(respAccepted.Payload) > 0 {
+		return &respAccepted.Payload, nil
 	}
 	return nil, fmt.Errorf("failed to Create PVM Instance")
 }
 
-// Delete PVM Instances
-func (f *IBMPIInstanceClient) Delete(id string) error {
-	params := p_cloud_p_vm_instances.NewPcloudPvminstancesDeleteParams().
-		WithContext(f.ctx).WithTimeout(helpers.PIDeleteTimeOut).
-		WithCloudInstanceID(f.cloudInstanceID).WithPvmInstanceID(id)
-	_, err := f.session.Power.PCloudpVMInstances.PcloudPvminstancesDelete(params, f.session.AuthInfo(f.cloudInstanceID))
+// Delete an Instance
+func (f *IBMPIInstanceClient) Delete(instanceID string) error {
+
+	// Create params and send request
+	params := &params.PcloudPvminstancesDeleteParams{
+		CloudInstanceID: f.cloudInstanceID,
+		Context:         f.context,
+		PvmInstanceID:   instanceID,
+	}
+	//params.SetTimeout(helpers.PIDeleteTimeOut)
+	_, err := f.request.PcloudPvminstancesDelete(params, f.auth)
+
+	// Handle Errors
 	if err != nil {
-		return fmt.Errorf("failed to Delete PVM Instance %s :%w", id, err)
+		return fmt.Errorf("failed to Delete PVM Instance %s :%w", instanceID, err)
 	}
 	return nil
 }
 
-// Update PVM Instances
-func (f *IBMPIInstanceClient) Update(id string, body *models.PVMInstanceUpdate) (*models.PVMInstanceUpdateResponse, error) {
-	params := p_cloud_p_vm_instances.NewPcloudPvminstancesPutParams().
-		WithContext(f.ctx).WithTimeout(helpers.PICreateTimeOut).
-		WithCloudInstanceID(f.cloudInstanceID).WithPvmInstanceID(id).WithBody(body)
-	resp, err := f.session.Power.PCloudpVMInstances.PcloudPvminstancesPut(params, f.session.AuthInfo(f.cloudInstanceID))
+// Update an Instance
+func (f *IBMPIInstanceClient) Update(instanceID string, updateBody *models.PVMInstanceUpdate) (*models.PVMInstanceUpdateResponse, error) {
+
+	// Create params and send request
+	params := &params.PcloudPvminstancesPutParams{
+		Body:            updateBody,
+		CloudInstanceID: f.cloudInstanceID,
+		Context:         f.context,
+		PvmInstanceID:   instanceID,
+	}
+	//params.SetTimeout(helpers.PICreateTimeOut)
+	resp, err := f.request.PcloudPvminstancesPut(params, f.auth)
+
+	// Handle Errors
 	if err != nil {
-		return nil, fmt.Errorf("failed to Update PVM Instance %s :%w", id, err)
+		return nil, fmt.Errorf("failed to Update PVM Instance %s :%w", instanceID, err)
 	}
 	if resp == nil || resp.Payload == nil {
-		return nil, fmt.Errorf("failed to Update PVM Instance %s", id)
+		return nil, fmt.Errorf("failed to Update PVM Instance %s", instanceID)
 	}
 	return resp.Payload, nil
 }
 
-// Action PVM Instances Operations
-func (f *IBMPIInstanceClient) Action(id string, body *models.PVMInstanceAction) error {
-	params := p_cloud_p_vm_instances.NewPcloudPvminstancesActionPostParams().
-		WithContext(f.ctx).WithTimeout(helpers.PICreateTimeOut).
-		WithCloudInstanceID(f.cloudInstanceID).WithPvmInstanceID(id).
-		WithBody(body)
-	_, err := f.session.Power.PCloudpVMInstances.PcloudPvminstancesActionPost(params, f.session.AuthInfo(f.cloudInstanceID))
-	if err != nil {
-		return fmt.Errorf("failed to perform Action on PVM Instance %s :%w", id, err)
-	}
-	return nil
+// Action Operation for an Instance
+func (f *IBMPIInstanceClient) Action(instanceID string, actionBody *models.PVMInstanceAction) error {
 
-}
+	// Create params and send request
+	params := &params.PcloudPvminstancesActionPostParams{
+		Body:            actionBody,
+		CloudInstanceID: f.cloudInstanceID,
+		Context:         f.context,
+		PvmInstanceID:   instanceID,
+	}
+	//params.SetTimeout(helpers.PICreateTimeOut)
+	_, err := f.request.PcloudPvminstancesActionPost(params, f.auth)
 
-// PostConsoleURL Generate the Console URL
-func (f *IBMPIInstanceClient) PostConsoleURL(id string) (*models.PVMInstanceConsole, error) {
-	params := p_cloud_p_vm_instances.NewPcloudPvminstancesConsolePostParams().
-		WithContext(f.ctx).WithTimeout(helpers.PICreateTimeOut).
-		WithCloudInstanceID(f.cloudInstanceID).WithPvmInstanceID(id)
-	postok, err := f.session.Power.PCloudpVMInstances.PcloudPvminstancesConsolePost(params, f.session.AuthInfo(f.cloudInstanceID))
+	// Handle Errors
 	if err != nil {
-		return nil, fmt.Errorf("failed to Generate the Console URL PVM Instance %s :%w", id, err)
-	}
-	if postok == nil || postok.Payload == nil {
-		return nil, fmt.Errorf("failed to Generate the Console URL PVM Instance %s", id)
-	}
-	return postok.Payload, nil
-}
-
-// List the available console languages for an instance
-func (f *IBMPIInstanceClient) GetConsoleLanguages(id string) (*models.ConsoleLanguages, error) {
-	params := p_cloud_p_vm_instances.NewPcloudPvminstancesConsoleGetParams().
-		WithContext(f.ctx).WithTimeout(helpers.PIGetTimeOut).
-		WithCloudInstanceID(f.cloudInstanceID).WithPvmInstanceID(id)
-	resp, err := f.session.Power.PCloudpVMInstances.PcloudPvminstancesConsoleGet(params, f.session.AuthInfo(f.cloudInstanceID))
-	if err != nil {
-		return nil, fmt.Errorf("failed to Get Console Languages for PVM Instance %s :%w", id, err)
-	}
-	if resp == nil || resp.Payload == nil {
-		return nil, fmt.Errorf("failed to Get Console Languages for PVM Instance %s", id)
-	}
-	return resp.Payload, nil
-}
-
-// List the available console languages for an instance
-func (f *IBMPIInstanceClient) UpdateConsoleLanguage(id string, body *models.ConsoleLanguage) (*models.ConsoleLanguage, error) {
-	params := p_cloud_p_vm_instances.NewPcloudPvminstancesConsolePutParams().
-		WithContext(f.ctx).WithTimeout(helpers.PIUpdateTimeOut).
-		WithCloudInstanceID(f.cloudInstanceID).WithPvmInstanceID(id).
-		WithBody(body)
-	resp, err := f.session.Power.PCloudpVMInstances.PcloudPvminstancesConsolePut(params, f.session.AuthInfo(f.cloudInstanceID))
-	if err != nil {
-		return nil, fmt.Errorf("failed to Update Console Language for PVM Instance %s :%w", id, err)
-	}
-	if resp == nil || resp.Payload == nil {
-		return nil, fmt.Errorf("failed to Update Console Language for PVM Instance %s", id)
-	}
-	return resp.Payload, nil
-}
-
-// CaptureInstanceToImageCatalog Captures an instance
-func (f *IBMPIInstanceClient) CaptureInstanceToImageCatalog(id string, body *models.PVMInstanceCapture) error {
-	params := p_cloud_p_vm_instances.NewPcloudPvminstancesCapturePostParams().
-		WithContext(f.ctx).WithTimeout(helpers.PIGetTimeOut).
-		WithCloudInstanceID(f.cloudInstanceID).WithPvmInstanceID(id).
-		WithBody(body)
-	_, _, err := f.session.Power.PCloudpVMInstances.PcloudPvminstancesCapturePost(params, f.session.AuthInfo(f.cloudInstanceID))
-	if err != nil {
-		return fmt.Errorf("failed to Capture the PVM Instance %s: %w", id, err)
+		return fmt.Errorf("failed to perform Action on PVM Instance %s :%w", instanceID, err)
 	}
 	return nil
 
 }
 
-//CaptureInstanceToImageCatalog Captures V2
-func (f *IBMPIInstanceClient) CaptureInstanceToImageCatalogV2(id string, body *models.PVMInstanceCapture) (*models.JobReference, error) {
-	params := p_cloud_p_vm_instances.NewPcloudV2PvminstancesCapturePostParams().
-		WithContext(f.ctx).WithTimeout(helpers.PIGetTimeOut).
-		WithCloudInstanceID(f.cloudInstanceID).WithPvmInstanceID(id).
-		WithBody(body)
-	resp, err := f.session.Power.PCloudpVMInstances.PcloudV2PvminstancesCapturePost(params, f.session.AuthInfo(f.cloudInstanceID))
+// Generate the Console URL for an Instance
+func (f *IBMPIInstanceClient) PostConsoleURL(instanceID string) (*models.PVMInstanceConsole, error) {
+
+	// Create params and send request
+	params := &params.PcloudPvminstancesConsolePostParams{
+		CloudInstanceID: f.cloudInstanceID,
+		Context:         f.context,
+		PvmInstanceID:   instanceID,
+	}
+	//params.SetTimeout(helpers.PICreateTimeOut)
+	respOk, err := f.request.PcloudPvminstancesConsolePost(params, f.auth)
+
+	// Handle Errors
 	if err != nil {
-		return nil, fmt.Errorf("failed to Capture the PVM Instance %s: %w", id, err)
+		return nil, fmt.Errorf("failed to Generate the Console URL PVM Instance %s :%w", instanceID, err)
+	}
+	if respOk == nil || respOk.Payload == nil {
+		return nil, fmt.Errorf("failed to Generate the Console URL PVM Instance %s", instanceID)
+	}
+	return respOk.Payload, nil
+}
+
+// List the available Console Languages for an Instance
+func (f *IBMPIInstanceClient) GetConsoleLanguages(instanceID string) (*models.ConsoleLanguages, error) {
+
+	// Create params and send request
+	params := &params.PcloudPvminstancesConsoleGetParams{
+		CloudInstanceID: f.cloudInstanceID,
+		Context:         f.context,
+		PvmInstanceID:   instanceID,
+	}
+	//params.SetTimeout(helpers.PIGetTimeOut)
+	resp, err := f.request.PcloudPvminstancesConsoleGet(params, f.auth)
+
+	// Handle Errors
+	if err != nil {
+		return nil, fmt.Errorf("failed to Get Console Languages for PVM Instance %s :%w", instanceID, err)
 	}
 	if resp == nil || resp.Payload == nil {
-		return nil, fmt.Errorf("failed to Capture the PVM Instance %s", id)
+		return nil, fmt.Errorf("failed to Get Console Languages for PVM Instance %s", instanceID)
 	}
 	return resp.Payload, nil
 }
 
-// CreatePvmSnapShot Create a snapshot of the instance
-func (f *IBMPIInstanceClient) CreatePvmSnapShot(id string, body *models.SnapshotCreate) (*models.SnapshotCreateResponse, error) {
-	params := p_cloud_p_vm_instances.NewPcloudPvminstancesSnapshotsPostParams().
-		WithContext(f.ctx).WithTimeout(helpers.PICreateTimeOut).
-		WithCloudInstanceID(f.cloudInstanceID).WithPvmInstanceID(id).
-		WithBody(body)
-	snapshotpostaccepted, err := f.session.Power.PCloudpVMInstances.PcloudPvminstancesSnapshotsPost(params, f.session.AuthInfo(f.cloudInstanceID))
-	if err != nil {
-		return nil, fmt.Errorf("failed to Create the snapshot for the pvminstance %s: %w", id, err)
-	}
-	if snapshotpostaccepted == nil || snapshotpostaccepted.Payload == nil {
-		return nil, fmt.Errorf("failed to Create the snapshot for the pvminstance %s", id)
-	}
-	return snapshotpostaccepted.Payload, nil
-}
+// Update the available Console Languages for an Instance
+func (f *IBMPIInstanceClient) UpdateConsoleLanguage(instanceID string, updateBody *models.ConsoleLanguage) (*models.ConsoleLanguage, error) {
 
-// CreateClone ...
-func (f *IBMPIInstanceClient) CreateClone(id string, body *models.PVMInstanceClone) (*models.PVMInstance, error) {
-	params := p_cloud_p_vm_instances.NewPcloudPvminstancesClonePostParams().
-		WithContext(f.ctx).WithTimeout(helpers.PICreateTimeOut).
-		WithCloudInstanceID(f.cloudInstanceID).WithPvmInstanceID(id).
-		WithBody(body)
-	clonePost, err := f.session.Power.PCloudpVMInstances.PcloudPvminstancesClonePost(params, f.session.AuthInfo(f.cloudInstanceID))
-	if err != nil {
-		return nil, fmt.Errorf("failed to create the clone of the pvm instance %s: %w", id, err)
+	// Create params and send request
+	params := &params.PcloudPvminstancesConsolePutParams{
+		Body:            updateBody,
+		CloudInstanceID: f.cloudInstanceID,
+		Context:         f.context,
+		PvmInstanceID:   instanceID,
 	}
-	if clonePost == nil || clonePost.Payload == nil {
-		return nil, fmt.Errorf("failed to create the clone of the pvm instance %s", id)
-	}
-	return clonePost.Payload, nil
-}
+	//params.SetTimeout(helpers.PIUpdateTimeOut)
+	resp, err := f.request.PcloudPvminstancesConsolePut(params, f.auth)
 
-// GetSnapShotVM Get information about the snapshots for a vm
-func (f *IBMPIInstanceClient) GetSnapShotVM(id string) (*models.Snapshots, error) {
-	params := p_cloud_p_vm_instances.NewPcloudPvminstancesSnapshotsGetallParams().
-		WithContext(f.ctx).WithTimeout(helpers.PICreateTimeOut).
-		WithCloudInstanceID(f.cloudInstanceID).WithPvmInstanceID(id)
-	resp, err := f.session.Power.PCloudpVMInstances.PcloudPvminstancesSnapshotsGetall(params, f.session.AuthInfo(f.cloudInstanceID))
+	// Handle Errors
 	if err != nil {
-		return nil, fmt.Errorf("failed to Get the snapshot for the pvminstance %s: %w", id, err)
+		return nil, fmt.Errorf("failed to Update Console Language for PVM Instance %s :%w", instanceID, err)
 	}
 	if resp == nil || resp.Payload == nil {
-		return nil, fmt.Errorf("failed to Get the snapshot for the pvminstance %s", id)
+		return nil, fmt.Errorf("failed to Update Console Language for PVM Instance %s", instanceID)
+	}
+	return resp.Payload, nil
+}
+
+// Capture an Instance
+func (f *IBMPIInstanceClient) CaptureInstanceToImageCatalog(instanceID string, captureBody *models.PVMInstanceCapture) error {
+
+	// Create params and send request
+	params := &params.PcloudPvminstancesCapturePostParams{
+		Body:            captureBody,
+		CloudInstanceID: f.cloudInstanceID,
+		Context:         f.context,
+		PvmInstanceID:   instanceID,
+	}
+	//params.SetTimeout(helpers.PIGetTimeOut)
+	_, _, err := f.request.PcloudPvminstancesCapturePost(params, f.auth)
+
+	// Handle Errors
+	if err != nil {
+		return fmt.Errorf("failed to Capture the PVM Instance %s: %w", instanceID, err)
+	}
+	return nil
+
+}
+
+// Capture an Instance (V2)
+func (f *IBMPIInstanceClient) CaptureInstanceToImageCatalogV2(instanceID string, captureBody *models.PVMInstanceCapture) (*models.JobReference, error) {
+
+	// Create params and send request
+	params := &params.PcloudV2PvminstancesCapturePostParams{
+		Body:            captureBody,
+		CloudInstanceID: f.cloudInstanceID,
+		Context:         f.context,
+		PvmInstanceID:   instanceID,
+	}
+	//params.SetTimeout(helpers.PIGetTimeOut)
+	resp, err := f.request.PcloudV2PvminstancesCapturePost(params, f.auth)
+
+	// Handle Errors
+	if err != nil {
+		return nil, fmt.Errorf("failed to Capture the PVM Instance %s: %w", instanceID, err)
+	}
+	if resp == nil || resp.Payload == nil {
+		return nil, fmt.Errorf("failed to Capture the PVM Instance %s", instanceID)
+	}
+	return resp.Payload, nil
+}
+
+// Create a snapshot of an Instance
+func (f *IBMPIInstanceClient) CreatePvmSnapShot(instanceID string, createBody *models.SnapshotCreate) (*models.SnapshotCreateResponse, error) {
+
+	// Create params and send request
+	params := &params.PcloudPvminstancesSnapshotsPostParams{
+		Body:            createBody,
+		CloudInstanceID: f.cloudInstanceID,
+		Context:         f.context,
+		PvmInstanceID:   instanceID,
+	}
+	//params.SetTimeout(helpers.PICreateTimeOut)
+	resp, err := f.request.PcloudPvminstancesSnapshotsPost(params, f.auth)
+
+	// Handle Errors
+	if err != nil {
+		return nil, fmt.Errorf("failed to Create the snapshot for the pvminstance %s: %w", instanceID, err)
+	}
+	if resp == nil || resp.Payload == nil {
+		return nil, fmt.Errorf("failed to Create the snapshot for the pvminstance %s", instanceID)
+	}
+	return resp.Payload, nil
+}
+
+// Creatte a CLone of an Instance
+func (f *IBMPIInstanceClient) CreateClone(instanceID string, createBody *models.PVMInstanceClone) (*models.PVMInstance, error) {
+
+	// Create params and send request
+	params := &params.PcloudPvminstancesClonePostParams{
+		Body:            createBody,
+		CloudInstanceID: f.cloudInstanceID,
+		Context:         f.context,
+		PvmInstanceID:   instanceID,
+	}
+	//params.SetTimeout(helpers.PICreateTimeOut)
+	resp, err := f.request.PcloudPvminstancesClonePost(params, f.auth)
+
+	// Handle Errors
+	if err != nil {
+		return nil, fmt.Errorf("failed to create the clone of the pvm instance %s: %w", instanceID, err)
+	}
+	if resp == nil || resp.Payload == nil {
+		return nil, fmt.Errorf("failed to create the clone of the pvm instance %s", instanceID)
+	}
+	return resp.Payload, nil
+}
+
+// Get a Snapshot of an Instance
+func (f *IBMPIInstanceClient) GetSnapShotVM(instanceID string) (*models.Snapshots, error) {
+
+	// Create params and send request
+	params := &params.PcloudPvminstancesSnapshotsGetallParams{
+		CloudInstanceID: f.cloudInstanceID,
+		Context:         f.context,
+		PvmInstanceID:   instanceID,
+	}
+	//params.SetTimeout(helpers.PIGetTimeOut)
+	resp, err := f.request.PcloudPvminstancesSnapshotsGetall(params, f.auth)
+
+	// Handle Errors
+	if err != nil {
+		return nil, fmt.Errorf("failed to Get the snapshot for the pvminstance %s: %w", instanceID, err)
+	}
+	if resp == nil || resp.Payload == nil {
+		return nil, fmt.Errorf("failed to Get the snapshot for the pvminstance %s", instanceID)
 	}
 	return resp.Payload, nil
 
 }
 
-// RestoreSnapShotVM Restore a snapshot
-func (f *IBMPIInstanceClient) RestoreSnapShotVM(id, snapshotid, restoreAction string, body *models.SnapshotRestore) (*models.Snapshot, error) {
-	params := p_cloud_p_vm_instances.NewPcloudPvminstancesSnapshotsRestorePostParams().
-		WithContext(f.ctx).WithTimeout(helpers.PICreateTimeOut).
-		WithCloudInstanceID(f.cloudInstanceID).WithPvmInstanceID(id).
-		WithSnapshotID(snapshotid).WithRestoreFailAction(&restoreAction).
-		WithBody(body)
-	resp, err := f.session.Power.PCloudpVMInstances.PcloudPvminstancesSnapshotsRestorePost(params, f.session.AuthInfo(f.cloudInstanceID))
+// Restore a Snapshot of an Instance
+func (f *IBMPIInstanceClient) RestoreSnapShotVM(instanceID, snapshotID, restoreAction string, updateBody *models.SnapshotRestore) (*models.Snapshot, error) {
+
+	// Create params and send request
+	params := &params.PcloudPvminstancesSnapshotsRestorePostParams{
+		Body:              updateBody,
+		CloudInstanceID:   f.cloudInstanceID,
+		Context:           f.context,
+		PvmInstanceID:     instanceID,
+		RestoreFailAction: &restoreAction,
+		SnapshotID:        snapshotID,
+	}
+	//params.SetTimeout(helpers.PICreateTimeOut)
+	resp, err := f.request.PcloudPvminstancesSnapshotsRestorePost(params, f.auth)
+
+	// Handle Errors
 	if err != nil {
-		return nil, fmt.Errorf("failed to restrore the snapshot for the pvminstance %s: %w", id, err)
+		return nil, fmt.Errorf("failed to restrore the snapshot for the pvminstance %s: %w", instanceID, err)
 	}
 	if resp == nil || resp.Payload == nil {
-		return nil, fmt.Errorf("failed to restrore the snapshot for the pvminstance %s", id)
+		return nil, fmt.Errorf("failed to restrore the snapshot for the pvminstance %s", instanceID)
 	}
 	return resp.Payload, nil
 }
 
-// AddNetwork Add a network to the instance
-func (f *IBMPIInstanceClient) AddNetwork(id string, body *models.PVMInstanceAddNetwork) (*models.PVMInstanceNetwork, error) {
-	params := p_cloud_p_vm_instances.NewPcloudPvminstancesNetworksPostParams().
-		WithContext(f.ctx).WithTimeout(helpers.PICreateTimeOut).
-		WithCloudInstanceID(f.cloudInstanceID).WithPvmInstanceID(id).
-		WithBody(body)
-	resp, err := f.session.Power.PCloudpVMInstances.PcloudPvminstancesNetworksPost(params, f.session.AuthInfo(f.cloudInstanceID))
+// Add a Network to an Instance
+func (f *IBMPIInstanceClient) AddNetwork(instanceID string, updateBody *models.PVMInstanceAddNetwork) (*models.PVMInstanceNetwork, error) {
+
+	// Create params and send request
+	params := &params.PcloudPvminstancesNetworksPostParams{
+		Body:            updateBody,
+		CloudInstanceID: f.cloudInstanceID,
+		Context:         f.context,
+		PvmInstanceID:   instanceID,
+	}
+	//params.SetTimeout(helpers.PICreateTimeOut)
+	resp, err := f.request.PcloudPvminstancesNetworksPost(params, f.auth)
+
+	// Handle Errors
 	if err != nil {
-		return nil, fmt.Errorf("failed to attach the network to the pvminstanceid %s: %w", id, err)
+		return nil, fmt.Errorf("failed to attach the network to the pvminstanceid %s: %w", instanceID, err)
 	}
 	if resp == nil || resp.Payload == nil {
-		return nil, fmt.Errorf("failed to attach the network to the pvminstanceid %s", id)
+		return nil, fmt.Errorf("failed to attach the network to the pvminstanceid %s", instanceID)
 	}
 	return resp.Payload, nil
 }
 
-// Delete a network from an instance
-func (f *IBMPIInstanceClient) DeleteNetwork(id string, body *models.PVMInstanceRemoveNetwork) error {
-	params := p_cloud_p_vm_instances.NewPcloudPvminstancesNetworksDeleteParams().
-		WithContext(f.ctx).WithTimeout(helpers.PICreateTimeOut).
-		WithCloudInstanceID(f.cloudInstanceID).WithPvmInstanceID(id).
-		WithBody(body)
-	_, err := f.session.Power.PCloudpVMInstances.PcloudPvminstancesNetworksDelete(params, f.session.AuthInfo(f.cloudInstanceID))
+// Delete a Network from an Instance
+func (f *IBMPIInstanceClient) DeleteNetwork(instanceID string, deleteBody *models.PVMInstanceRemoveNetwork) error {
+
+	// Create params and send request
+	params := &params.PcloudPvminstancesNetworksDeleteParams{
+		Body:            deleteBody,
+		CloudInstanceID: f.cloudInstanceID,
+		Context:         f.context,
+		PvmInstanceID:   instanceID,
+	}
+	//params.SetTimeout(helpers.PIDeleteTimeOut)
+	_, err := f.request.PcloudPvminstancesNetworksDelete(params, f.auth)
+
+	// Handle Errors
 	if err != nil {
-		return fmt.Errorf("failed to delete the network to the pvminstanceid %s: %w", id, err)
+		return fmt.Errorf("failed to delete the network to the pvminstanceid %s: %w", instanceID, err)
 	}
 	return nil
 }


### PR DESCRIPTION
- Create Params with structs instead of a function
- Use default service broker timeout (previous timeout is commented out)
- Eliminated need for `IBMPIClient` and `ibm_pi_helper.go`
  - I plan on removing these in a different PR