### PR TITLE
Cleaned up CloudInstance

### DIFF
--- a/clients/instance/ibm-pi-cloud-instance.go
+++ b/clients/instance/ibm-pi-cloud-instance.go
@@ -5,63 +5,85 @@ import (
 	"fmt"
 
 	"github.com/IBM-Cloud/power-go-client/errors"
-	"github.com/IBM-Cloud/power-go-client/helpers"
-
 	"github.com/IBM-Cloud/power-go-client/ibmpisession"
-	"github.com/IBM-Cloud/power-go-client/power/client/p_cloud_instances"
+	params "github.com/IBM-Cloud/power-go-client/power/client/p_cloud_instances"
 	"github.com/IBM-Cloud/power-go-client/power/models"
+	"github.com/go-openapi/runtime"
 )
 
 // IBMPICloudInstanceClient ...
 type IBMPICloudInstanceClient struct {
-	IBMPIClient
+	auth    runtime.ClientAuthInfoWriter
+	context context.Context
+	request params.ClientService
 }
 
 // NewIBMPICloudInstanceClient ...
 func NewIBMPICloudInstanceClient(ctx context.Context, sess *ibmpisession.IBMPISession, cloudInstanceID string) *IBMPICloudInstanceClient {
 	return &IBMPICloudInstanceClient{
-		*NewIBMPIClient(ctx, sess, cloudInstanceID),
+		auth:    sess.AuthInfo(cloudInstanceID),
+		context: ctx,
+		request: sess.Power.PCloudInstances,
 	}
 }
 
-// Get information about a cloud instance
-func (f *IBMPICloudInstanceClient) Get(id string) (*models.CloudInstance, error) {
-	params := p_cloud_instances.NewPcloudCloudinstancesGetParams().
-		WithContext(f.ctx).WithTimeout(helpers.PIGetTimeOut).
-		WithCloudInstanceID(id)
-	resp, err := f.session.Power.PCloudInstances.PcloudCloudinstancesGet(params, f.session.AuthInfo(f.cloudInstanceID))
+// Get a Cloud Instance
+func (f *IBMPICloudInstanceClient) Get(cloudInstanceID string) (*models.CloudInstance, error) {
+
+	// Create params and send request
+	params := &params.PcloudCloudinstancesGetParams{
+		CloudInstanceID: cloudInstanceID,
+		Context:         f.context,
+	}
+	//params.SetTimeout(helpers.PIGetTimeOut)
+	resp, err := f.request.PcloudCloudinstancesGet(params, f.auth)
+
+	// Handle errors
 	if err != nil {
-		return nil, fmt.Errorf(errors.GetCloudInstanceOperationFailed, id, err)
+		return nil, fmt.Errorf(errors.GetCloudInstanceOperationFailed, cloudInstanceID, err)
 	}
 	if resp == nil || resp.Payload == nil {
-		return nil, fmt.Errorf("failed to Get Cloud Instance %s", id)
+		return nil, fmt.Errorf("failed to Get Cloud Instance %s", cloudInstanceID)
 	}
 	return resp.Payload, nil
 }
 
-// Update a cloud instance
-func (f *IBMPICloudInstanceClient) Update(id string, body *models.CloudInstanceUpdate) (*models.CloudInstance, error) {
-	params := p_cloud_instances.NewPcloudCloudinstancesPutParams().
-		WithContext(f.ctx).WithTimeout(helpers.PIUpdateTimeOut).
-		WithCloudInstanceID(id).WithBody(body)
-	resp, err := f.session.Power.PCloudInstances.PcloudCloudinstancesPut(params, f.session.AuthInfo(f.cloudInstanceID))
+// Update a Cloud Instance
+func (f *IBMPICloudInstanceClient) Update(cloudInstanceID string, updateBody *models.CloudInstanceUpdate) (*models.CloudInstance, error) {
+
+	// Create params and send request
+	params := &params.PcloudCloudinstancesPutParams{
+		Body:            updateBody,
+		CloudInstanceID: cloudInstanceID,
+		Context:         f.context,
+	}
+	//params.SetTimeout(helpers.PIUpdateTimeOut)
+	resp, err := f.request.PcloudCloudinstancesPut(params, f.auth)
+
+	// Handle errors
 	if err != nil {
-		return nil, fmt.Errorf(errors.UpdateCloudInstanceOperationFailed, id, err)
+		return nil, fmt.Errorf(errors.UpdateCloudInstanceOperationFailed, cloudInstanceID, err)
 	}
 	if resp == nil || resp.Payload == nil {
-		return nil, fmt.Errorf("failed to update the Cloud instance %s", id)
+		return nil, fmt.Errorf("failed to update the Cloud instance %s", cloudInstanceID)
 	}
 	return resp.Payload, nil
 }
 
-// Delete a Cloud instance
-func (f *IBMPICloudInstanceClient) Delete(id string) error {
-	params := p_cloud_instances.NewPcloudCloudinstancesDeleteParams().
-		WithContext(f.ctx).WithTimeout(helpers.PIDeleteTimeOut).
-		WithCloudInstanceID(id)
-	_, err := f.session.Power.PCloudInstances.PcloudCloudinstancesDelete(params, f.session.AuthInfo(f.cloudInstanceID))
+// Delete a Cloud Instance
+func (f *IBMPICloudInstanceClient) Delete(cloudInstanceID string) error {
+
+	// Create params and send request
+	params := &params.PcloudCloudinstancesDeleteParams{
+		CloudInstanceID: cloudInstanceID,
+		Context:         f.context,
+	}
+	//params.SetTimeout(helpers.PIDeleteTimeOut)
+
+	// Handle errors
+	_, err := f.request.PcloudCloudinstancesDelete(params, f.auth)
 	if err != nil {
-		return fmt.Errorf(errors.DeleteCloudInstanceOperationFailed, id, err)
+		return fmt.Errorf(errors.DeleteCloudInstanceOperationFailed, cloudInstanceID, err)
 	}
 	return nil
 }


### PR DESCRIPTION
- Create Params with structs instead of a function
- Use default service broker timeout (previous timeout is commented out)
- Eliminated need for `IBMPIClient` and `ibm_pi_helper.go`
  - I plan on removing these in a different PR