### PR TITLE
Add replication enabled attribute in volume resource

### DIFF
--- a/clients/instance/ibm-pi-volume.go
+++ b/clients/instance/ibm-pi-volume.go
@@ -212,3 +212,15 @@ func (f *IBMPIVolumeClient) UpdateVolumeAttach(id, volumeID string, body *models
 	}
 	return nil
 }
+
+// Performs action on volume
+func (f *IBMPIVolumeClient) VolumeAction(id string, body *models.VolumeAction) error {
+	params := p_cloud_volumes.NewPcloudCloudinstancesVolumesActionPostParams().
+		WithContext(f.ctx).WithTimeout(helpers.PIUpdateTimeOut).
+		WithCloudInstanceID(f.cloudInstanceID).WithVolumeID(id).WithBody(body)
+	_, err := f.session.Power.PCloudVolumes.PcloudCloudinstancesVolumesActionPost(params, f.session.AuthInfo(f.cloudInstanceID))
+	if err != nil {
+		return fmt.Errorf("failed to perform action on volume %s with error %w", id, err)
+	}
+	return nil
+}

--- a/helpers/constants.go
+++ b/helpers/constants.go
@@ -64,6 +64,7 @@ const (
 	PIAffinityDiskCount       = "pi_volume_disk_count"
 	PIStoragePoolValue        = "pi_storage_pool_type"
 	PIStoragePoolName         = "pi_storage_pool_name"
+	PIReplicationEnabled      = "pi_replication_enabled"
 
 	// IBM PI Snapshots
 


### PR DESCRIPTION
- Adding `pi_replication_enabled` attribute to be accessed in terraform `ibm_pi_volume` resource