### PR TITLE
Undo volume replication-enabled safeguards

### DIFF
--- a/clients/instance/ibm-pi-volume.go
+++ b/clients/instance/ibm-pi-volume.go
@@ -44,10 +44,6 @@ func (f *IBMPIVolumeClient) GetAll() (*models.Volumes, error) {
 	params := p_cloud_volumes.NewPcloudCloudinstancesVolumesGetallParams().
 		WithContext(f.ctx).WithTimeout(helpers.PIGetTimeOut).
 		WithCloudInstanceID(f.cloudInstanceID)
-	// Check for satellite differences in this endpoint
-	if f.session.IsOnPrem() && (params.Auxiliary != nil && params.ReplicationEnabled != nil) {
-		return nil, fmt.Errorf("auxiliary and replication enabled parameters are not supported in satellite location, check documentation")
-	}
 	resp, err := f.session.Power.PCloudVolumes.PcloudCloudinstancesVolumesGetall(params, f.session.AuthInfo(f.cloudInstanceID))
 	if err != nil {
 		return nil, fmt.Errorf("failed to Get all Volumes for Cloud Instance %s: %w", f.cloudInstanceID, err)
@@ -75,10 +71,6 @@ func (f *IBMPIVolumeClient) GetAllAffinityVolumes(affinity string) (*models.Volu
 
 // Create a VolumeV2
 func (f *IBMPIVolumeClient) CreateVolumeV2(body *models.MultiVolumesCreate) (*models.Volumes, error) {
-	// Check for satellite differences in this endpoint
-	if f.session.IsOnPrem() && body.ReplicationEnabled != nil {
-		return nil, fmt.Errorf("replication enabled parameter is not supported in satellite location, check documentation")
-	}
 	params := p_cloud_volumes.NewPcloudV2VolumesPostParams().
 		WithContext(f.ctx).WithTimeout(helpers.PICreateTimeOut).
 		WithCloudInstanceID(f.cloudInstanceID).WithBody(body)
@@ -94,10 +86,6 @@ func (f *IBMPIVolumeClient) CreateVolumeV2(body *models.MultiVolumesCreate) (*mo
 
 // Create a Volume
 func (f *IBMPIVolumeClient) CreateVolume(body *models.CreateDataVolume) (*models.Volume, error) {
-	// Check for satellite differences in this endpoint
-	if f.session.IsOnPrem() && body.ReplicationEnabled != nil {
-		return nil, fmt.Errorf("replication enabled parameter is not supported in satellite location, check documentation")
-	}
 	params := p_cloud_volumes.NewPcloudCloudinstancesVolumesPostParams().
 		WithContext(f.ctx).WithTimeout(helpers.PICreateTimeOut).
 		WithCloudInstanceID(f.cloudInstanceID).WithBody(body)
@@ -227,10 +215,6 @@ func (f *IBMPIVolumeClient) UpdateVolumeAttach(id, volumeID string, body *models
 
 // Performs action on volume
 func (f *IBMPIVolumeClient) VolumeAction(id string, body *models.VolumeAction) error {
-	// Check for satellite differences in this endpoint
-	if f.session.IsOnPrem() && body.ReplicationEnabled != nil {
-		return fmt.Errorf("replication enabled parameter is not supported in satellite location, check documentation")
-	}
 	params := p_cloud_volumes.NewPcloudCloudinstancesVolumesActionPostParams().
 		WithContext(f.ctx).WithTimeout(helpers.PIUpdateTimeOut).
 		WithCloudInstanceID(f.cloudInstanceID).WithVolumeID(id).WithBody(body)


### PR DESCRIPTION
I was unclear as to how we wanted to approach this first, but the consensus was to have the service broker use its existing blocks to prevent stratos from using GRS functionality. As a result, I am removing these redundant checks.