### PR TITLE
Add error handling for HTTP >500 errors

### DIFF
--- a/clients/instance/ibm-pi-clonevolumes.go
+++ b/clients/instance/ibm-pi-clonevolumes.go
@@ -31,7 +31,7 @@ func (f *IBMPICloneVolumeClient) Create(body *models.VolumesCloneAsyncRequest) (
 		WithCloudInstanceID(f.cloudInstanceID).WithBody(body)
 	resp, err := f.session.Power.PCloudVolumes.PcloudV2VolumesClonePost(params, f.session.AuthInfo(f.cloudInstanceID))
 	if err != nil {
-		return nil, fmt.Errorf(errors.CreateCloneOperationFailed, err)
+		return nil, ibmpisession.SDKFailWithAPIError(err, fmt.Sprintf(errors.CreateCloneOperationFailed, err))
 	}
 	if resp == nil || resp.Payload == nil {
 		return nil, fmt.Errorf("failed to perform the create clone operation")
@@ -46,7 +46,7 @@ func (f *IBMPICloneVolumeClient) Get(cloneTaskID string) (*models.CloneTaskStatu
 		WithCloudInstanceID(f.cloudInstanceID).WithCloneTaskID(cloneTaskID)
 	resp, err := f.session.Power.PCloudVolumes.PcloudV2VolumesClonetasksGet(params, f.session.AuthInfo(f.cloudInstanceID))
 	if err != nil {
-		return nil, fmt.Errorf("failed to get the clone task %s status for the cloud instance %s with error %w", cloneTaskID, f.cloudInstanceID, err)
+		return nil, ibmpisession.SDKFailWithAPIError(err, fmt.Sprintf("failed to get the clone task %s status for the cloud instance %s with error %v", cloneTaskID, f.cloudInstanceID, err))
 	}
 	if resp == nil || resp.Payload == nil {
 		return nil, fmt.Errorf("failed to get the clone task %s status for the cloud instance %s", cloneTaskID, f.cloudInstanceID)
@@ -61,7 +61,7 @@ func (f *IBMPICloneVolumeClient) CreateV2Clone(body *models.VolumesCloneCreate) 
 		WithCloudInstanceID(f.cloudInstanceID).WithBody(body)
 	resp, err := f.session.Power.PCloudVolumes.PcloudV2VolumesclonePost(params, f.session.AuthInfo(f.cloudInstanceID))
 	if err != nil {
-		return nil, fmt.Errorf(errors.PrepareCloneOperationFailed, *body.Name, err)
+		return nil, ibmpisession.SDKFailWithAPIError(err, fmt.Sprintf(errors.PrepareCloneOperationFailed, *body.Name, err))
 	}
 	if resp == nil || resp.Payload == nil {
 		return nil, fmt.Errorf("failed to prepare the clone operation")
@@ -76,7 +76,7 @@ func (f *IBMPICloneVolumeClient) GetV2Clones(queryFilter string) (*models.Volume
 		WithCloudInstanceID(f.cloudInstanceID).WithFilter(&queryFilter)
 	resp, err := f.session.Power.PCloudVolumes.PcloudV2VolumescloneGetall(params, f.session.AuthInfo(f.cloudInstanceID))
 	if err != nil {
-		return nil, fmt.Errorf("failed to get the volumes-clones for the cloud instance %s with error %w", f.cloudInstanceID, err)
+		return nil, ibmpisession.SDKFailWithAPIError(err, fmt.Sprintf("failed to get the volumes-clones for the cloud instance %s with error %v", f.cloudInstanceID, err))
 	}
 	if resp == nil || resp.Payload == nil {
 		return nil, fmt.Errorf("failed to get the volumes-clones for the cloud instance %s", f.cloudInstanceID)
@@ -103,7 +103,7 @@ func (f *IBMPICloneVolumeClient) StartClone(volumesCloneID string) (*models.Volu
 		WithCloudInstanceID(f.cloudInstanceID).WithVolumesCloneID(volumesCloneID)
 	resp, err := f.session.Power.PCloudVolumes.PcloudV2VolumescloneStartPost(params, f.session.AuthInfo(f.cloudInstanceID))
 	if err != nil {
-		return nil, fmt.Errorf(errors.StartCloneOperationFailed, volumesCloneID, err)
+		return nil, ibmpisession.SDKFailWithAPIError(err, fmt.Sprintf(errors.StartCloneOperationFailed, volumesCloneID, err))
 	}
 	if resp == nil || resp.Payload == nil {
 		return nil, fmt.Errorf("failed to start the clone operation for volume-clone %s", volumesCloneID)
@@ -118,7 +118,7 @@ func (f *IBMPICloneVolumeClient) PrepareClone(volumesCloneID string) (*models.Vo
 		WithCloudInstanceID(f.cloudInstanceID).WithVolumesCloneID(volumesCloneID)
 	resp, err := f.session.Power.PCloudVolumes.PcloudV2VolumescloneExecutePost(params, f.session.AuthInfo(f.cloudInstanceID))
 	if err != nil {
-		return nil, fmt.Errorf(errors.PrepareCloneOperationFailed, volumesCloneID, err)
+		return nil, ibmpisession.SDKFailWithAPIError(err, fmt.Sprintf(errors.PrepareCloneOperationFailed, volumesCloneID, err))
 	}
 	if resp == nil || resp.Payload == nil {
 		return nil, fmt.Errorf("failed to prepare the clone operation for %s", volumesCloneID)
@@ -133,7 +133,7 @@ func (f *IBMPICloneVolumeClient) GetV2CloneStatus(cloneName string) (*models.Vol
 		WithCloudInstanceID(f.cloudInstanceID).WithVolumesCloneID(cloneName)
 	resp, err := f.session.Power.PCloudVolumes.PcloudV2VolumescloneGet(params, f.session.AuthInfo(f.cloudInstanceID))
 	if err != nil {
-		return nil, fmt.Errorf(errors.GetCloneOperationFailed, cloneName, f.cloudInstanceID, err)
+		return nil, ibmpisession.SDKFailWithAPIError(err, fmt.Sprintf(errors.GetCloneOperationFailed, cloneName, f.cloudInstanceID, err))
 	}
 	if resp == nil || resp.Payload == nil {
 		return nil, fmt.Errorf("failed to get the volumes-clone %s for the cloud instance %s", cloneName, f.cloudInstanceID)

--- a/clients/instance/ibm-pi-cloud-connection.go
+++ b/clients/instance/ibm-pi-cloud-connection.go
@@ -34,7 +34,7 @@ func (f *IBMPICloudConnectionClient) Create(body *models.CloudConnectionCreate) 
 		WithCloudInstanceID(f.cloudInstanceID).WithBody(body)
 	postok, postcreated, postaccepted, err := f.session.Power.PCloudCloudConnections.PcloudCloudconnectionsPost(params, f.session.AuthInfo(f.cloudInstanceID))
 	if err != nil {
-		return nil, nil, fmt.Errorf(errors.CreateCloudConnectionOperationFailed, f.cloudInstanceID, err)
+		return nil, nil, ibmpisession.SDKFailWithAPIError(err, fmt.Sprintf(errors.CreateCloudConnectionOperationFailed, f.cloudInstanceID, err))
 	}
 	if postok != nil && postok.Payload != nil {
 		return postok.Payload, nil, nil
@@ -58,7 +58,7 @@ func (f *IBMPICloudConnectionClient) Get(id string) (*models.CloudConnection, er
 		WithCloudInstanceID(f.cloudInstanceID).WithCloudConnectionID(id)
 	resp, err := f.session.Power.PCloudCloudConnections.PcloudCloudconnectionsGet(params, f.session.AuthInfo(f.cloudInstanceID))
 	if err != nil {
-		return nil, fmt.Errorf(errors.GetCloudConnectionOperationFailed, id, err)
+		return nil, ibmpisession.SDKFailWithAPIError(err, fmt.Sprintf(errors.GetCloudConnectionOperationFailed, id, err))
 	}
 	if resp == nil || resp.Payload == nil {
 		return nil, fmt.Errorf("failed to perform Get Cloud Connections Operation for cloudconnectionid %s", id)
@@ -76,7 +76,7 @@ func (f *IBMPICloudConnectionClient) GetAll() (*models.CloudConnections, error) 
 		WithCloudInstanceID(f.cloudInstanceID)
 	resp, err := f.session.Power.PCloudCloudConnections.PcloudCloudconnectionsGetall(params, f.session.AuthInfo(f.cloudInstanceID))
 	if err != nil {
-		return nil, fmt.Errorf("failed to Get all Cloud Connections: %w", err)
+		return nil, ibmpisession.SDKFailWithAPIError(err, fmt.Sprintf("failed to Get all Cloud Connections: %v", err))
 	}
 	if resp == nil || resp.Payload == nil {
 		return nil, fmt.Errorf("failed to Get all Cloud Connections")
@@ -95,7 +95,7 @@ func (f *IBMPICloudConnectionClient) Update(id string, body *models.CloudConnect
 		WithBody(body)
 	putok, putaccepted, err := f.session.Power.PCloudCloudConnections.PcloudCloudconnectionsPut(params, f.session.AuthInfo(f.cloudInstanceID))
 	if err != nil {
-		return nil, nil, fmt.Errorf(errors.UpdateCloudConnectionOperationFailed, id, err)
+		return nil, nil, ibmpisession.SDKFailWithAPIError(err, fmt.Sprintf(errors.UpdateCloudConnectionOperationFailed, id, err))
 	}
 	if putok != nil && putok.Payload != nil {
 		return putok.Payload, nil, nil
@@ -116,7 +116,7 @@ func (f *IBMPICloudConnectionClient) Delete(id string) (*models.JobReference, er
 		WithCloudInstanceID(f.cloudInstanceID).WithCloudConnectionID(id)
 	_, delaccepted, err := f.session.Power.PCloudCloudConnections.PcloudCloudconnectionsDelete(params, f.session.AuthInfo(f.cloudInstanceID))
 	if err != nil {
-		return nil, fmt.Errorf(errors.DeleteCloudConnectionOperationFailed, id, err)
+		return nil, ibmpisession.SDKFailWithAPIError(err, fmt.Sprintf(errors.DeleteCloudConnectionOperationFailed, id, err))
 	}
 	if delaccepted != nil && delaccepted.Payload != nil {
 		return delaccepted.Payload, nil
@@ -135,7 +135,7 @@ func (f *IBMPICloudConnectionClient) AddNetwork(id, networkID string) (models.Ob
 		WithNetworkID(networkID)
 	respok, respAccepted, err := f.session.Power.PCloudCloudConnections.PcloudCloudconnectionsNetworksPut(params, f.session.AuthInfo(f.cloudInstanceID))
 	if err != nil {
-		return nil, nil, fmt.Errorf("failed to Add Network %s to Cloud Connection %s: %w", networkID, id, err)
+		return nil, nil, ibmpisession.SDKFailWithAPIError(err, fmt.Sprintf("failed to Add Network %s to Cloud Connection %s: %v", networkID, id, err))
 	}
 	if respok != nil && respok.Payload != nil {
 		return respok.Payload, nil, nil
@@ -157,7 +157,7 @@ func (f *IBMPICloudConnectionClient) DeleteNetwork(id, networkID string) (models
 		WithNetworkID(networkID)
 	respok, respAccepted, err := f.session.Power.PCloudCloudConnections.PcloudCloudconnectionsNetworksDelete(params, f.session.AuthInfo(f.cloudInstanceID))
 	if err != nil {
-		return nil, nil, fmt.Errorf("failed to Delete Network %s from Cloud Connection %s: %w", networkID, id, err)
+		return nil, nil, ibmpisession.SDKFailWithAPIError(err, fmt.Sprintf("failed to Delete Network %s from Cloud Connection %s: %v", networkID, id, err))
 	}
 	if respok != nil && respok.Payload != nil {
 		return respok.Payload, nil, nil
@@ -179,7 +179,7 @@ func (f *IBMPICloudConnectionClient) GetVPC() (*models.CloudConnectionVirtualPri
 
 	resp, err := f.session.Power.PCloudCloudConnections.PcloudCloudconnectionsVirtualprivatecloudsGetall(params, f.session.AuthInfo(f.cloudInstanceID))
 	if err != nil {
-		return nil, fmt.Errorf("failed to perform the get vpc operation: %w", err)
+		return nil, ibmpisession.SDKFailWithAPIError(err, fmt.Sprintf("failed to perform the get vpc operation: %v", err))
 	}
 	if resp.Payload == nil {
 		return nil, fmt.Errorf("failed to perform the get vpc operation")

--- a/clients/instance/ibm-pi-cloud-instance.go
+++ b/clients/instance/ibm-pi-cloud-instance.go
@@ -31,7 +31,7 @@ func (f *IBMPICloudInstanceClient) Get(id string) (*models.CloudInstance, error)
 		WithCloudInstanceID(id)
 	resp, err := f.session.Power.PCloudInstances.PcloudCloudinstancesGet(params, f.session.AuthInfo(f.cloudInstanceID))
 	if err != nil {
-		return nil, fmt.Errorf(errors.GetCloudInstanceOperationFailed, id, err)
+		return nil, ibmpisession.SDKFailWithAPIError(err, fmt.Sprintf(errors.GetCloudInstanceOperationFailed, id, err))
 	}
 	if resp == nil || resp.Payload == nil {
 		return nil, fmt.Errorf("failed to Get Cloud Instance %s", id)
@@ -46,7 +46,7 @@ func (f *IBMPICloudInstanceClient) Update(id string, body *models.CloudInstanceU
 		WithCloudInstanceID(id).WithBody(body)
 	resp, err := f.session.Power.PCloudInstances.PcloudCloudinstancesPut(params, f.session.AuthInfo(f.cloudInstanceID))
 	if err != nil {
-		return nil, fmt.Errorf(errors.UpdateCloudInstanceOperationFailed, id, err)
+		return nil, ibmpisession.SDKFailWithAPIError(err, fmt.Sprintf(errors.UpdateCloudInstanceOperationFailed, id, err))
 	}
 	if resp == nil || resp.Payload == nil {
 		return nil, fmt.Errorf("failed to update the Cloud instance %s", id)

--- a/clients/instance/ibm-pi-dhcp.go
+++ b/clients/instance/ibm-pi-dhcp.go
@@ -31,7 +31,7 @@ func (f *IBMPIDhcpClient) Create(body *models.DHCPServerCreate) (*models.DHCPSer
 		WithCloudInstanceID(f.cloudInstanceID).WithBody(body)
 	postaccepted, err := f.session.Power.PCloudServicedhcp.PcloudDhcpPost(params, f.session.AuthInfo(f.cloudInstanceID))
 	if err != nil {
-		return nil, fmt.Errorf(errors.CreateDchpOperationFailed, f.cloudInstanceID, err)
+		return nil, ibmpisession.SDKFailWithAPIError(err, fmt.Sprintf(errors.CreateDchpOperationFailed, f.cloudInstanceID, err))
 	}
 	if postaccepted != nil && postaccepted.Payload != nil {
 		return postaccepted.Payload, nil
@@ -46,7 +46,7 @@ func (f *IBMPIDhcpClient) Get(id string) (*models.DHCPServerDetail, error) {
 		WithCloudInstanceID(f.cloudInstanceID).WithDhcpID(id)
 	resp, err := f.session.Power.PCloudServicedhcp.PcloudDhcpGet(params, f.session.AuthInfo(f.cloudInstanceID))
 	if err != nil {
-		return nil, fmt.Errorf(errors.GetDhcpOperationFailed, id, err)
+		return nil, ibmpisession.SDKFailWithAPIError(err, fmt.Sprintf(errors.GetDhcpOperationFailed, id, err))
 	}
 	if resp == nil || resp.Payload == nil {
 		return nil, fmt.Errorf("failed to Get DHCP %s", id)
@@ -61,7 +61,7 @@ func (f *IBMPIDhcpClient) GetAll() (models.DHCPServers, error) {
 		WithCloudInstanceID(f.cloudInstanceID)
 	resp, err := f.session.Power.PCloudServicedhcp.PcloudDhcpGetall(params, f.session.AuthInfo(f.cloudInstanceID))
 	if err != nil {
-		return nil, fmt.Errorf("failed to Get all DHCP servers: %w", err)
+		return nil, ibmpisession.SDKFailWithAPIError(err, fmt.Sprintf("failed to Get all DHCP servers: %v", err))
 	}
 	if resp == nil || resp.Payload == nil {
 		return nil, fmt.Errorf("failed to Get all DHCP servers")

--- a/clients/instance/ibm-pi-dr-location.go
+++ b/clients/instance/ibm-pi-dr-location.go
@@ -33,7 +33,7 @@ func (f *IBMPIDisasterRecoveryLocationClient) Get() (*models.DisasterRecoveryLoc
 		WithCloudInstanceID(f.cloudInstanceID)
 	resp, err := f.session.Power.PCloudDisasterRecovery.PcloudLocationsDisasterrecoveryGet(params, f.session.AuthInfo(f.cloudInstanceID))
 	if err != nil {
-		return nil, fmt.Errorf(errors.GetDisasterRecoveryLocationOperationFailed, f.cloudInstanceID, err)
+		return nil, ibmpisession.SDKFailWithAPIError(err, fmt.Sprintf(errors.GetDisasterRecoveryLocationOperationFailed, f.cloudInstanceID, err))
 	}
 	if resp == nil || resp.Payload == nil {
 		return nil, fmt.Errorf("failed to perform the Get Disaster Recovery Location for the cloud instance %s", f.cloudInstanceID)
@@ -50,7 +50,7 @@ func (f *IBMPIDisasterRecoveryLocationClient) GetAll() (*models.DisasterRecovery
 		WithContext(f.ctx).WithTimeout(helpers.PIGetTimeOut)
 	resp, err := f.session.Power.PCloudDisasterRecovery.PcloudLocationsDisasterrecoveryGetall(params, f.session.AuthInfo(f.cloudInstanceID))
 	if err != nil {
-		return nil, fmt.Errorf(errors.GetAllDisasterRecoveryLocationOperationFailed, err)
+		return nil, ibmpisession.SDKFailWithAPIError(err, fmt.Sprintf(errors.GetAllDisasterRecoveryLocationOperationFailed, err))
 	}
 	if resp == nil || resp.Payload == nil {
 		return nil, fmt.Errorf("failed to Get All Disaster Recovery Location of Power Virtual Server")

--- a/clients/instance/ibm-pi-image.go
+++ b/clients/instance/ibm-pi-image.go
@@ -14,7 +14,7 @@ import (
 	"github.com/IBM-Cloud/power-go-client/power/models"
 )
 
-//IBMPIImageClient
+// IBMPIImageClient
 type IBMPIImageClient struct {
 	IBMPIClient
 }
@@ -33,7 +33,7 @@ func (f *IBMPIImageClient) Get(id string) (*models.Image, error) {
 		WithCloudInstanceID(f.cloudInstanceID).WithImageID(id)
 	resp, err := f.session.Power.PCloudImages.PcloudCloudinstancesImagesGet(params, f.session.AuthInfo(f.cloudInstanceID))
 	if err != nil {
-		return nil, fmt.Errorf(errors.GetImageOperationFailed, id, err)
+		return nil, ibmpisession.SDKFailWithAPIError(err, fmt.Sprintf(errors.GetImageOperationFailed, id, err))
 	}
 	if resp == nil || resp.Payload == nil {
 		return nil, fmt.Errorf("failed to perform Get Image Operation for image %s", id)
@@ -48,7 +48,7 @@ func (f *IBMPIImageClient) GetAll() (*models.Images, error) {
 		WithCloudInstanceID(f.cloudInstanceID)
 	resp, err := f.session.Power.PCloudImages.PcloudCloudinstancesImagesGetall(params, f.session.AuthInfo(f.cloudInstanceID))
 	if err != nil {
-		return nil, fmt.Errorf("failed to Get all PI Images of the PVM instance %s : %w", f.cloudInstanceID, err)
+		return nil, ibmpisession.SDKFailWithAPIError(err, fmt.Sprintf("failed to Get all PI Images of the PVM instance %s : %v", f.cloudInstanceID, err))
 	}
 	if resp == nil || resp.Payload == nil {
 		return nil, fmt.Errorf("failed to Get all PI Images of the PVM instance %s", f.cloudInstanceID)
@@ -66,7 +66,7 @@ func (f *IBMPIImageClient) Create(body *models.CreateImage) (*models.Image, erro
 		WithCloudInstanceID(f.cloudInstanceID).WithBody(body)
 	respok, respcreated, err := f.session.Power.PCloudImages.PcloudCloudinstancesImagesPost(params, f.session.AuthInfo(f.cloudInstanceID))
 	if err != nil {
-		return nil, fmt.Errorf(errors.CreateImageOperationFailed, f.cloudInstanceID, err)
+		return nil, ibmpisession.SDKFailWithAPIError(err, fmt.Sprintf(errors.CreateImageOperationFailed, f.cloudInstanceID, err))
 	}
 	if respok != nil && respok.Payload != nil {
 		return respok.Payload, nil
@@ -84,7 +84,7 @@ func (f *IBMPIImageClient) CreateCosImage(body *models.CreateCosImageImportJob) 
 		WithCloudInstanceID(f.cloudInstanceID).WithBody(body)
 	resp, err := f.session.Power.PCloudImages.PcloudV1CloudinstancesCosimagesPost(params, f.session.AuthInfo(f.cloudInstanceID))
 	if err != nil {
-		return nil, fmt.Errorf("failed to perform Create COS Image Operation for cloud instance %s with error %w", f.cloudInstanceID, err)
+		return nil, ibmpisession.SDKFailWithAPIError(err, fmt.Sprintf("failed to perform Create COS Image Operation for cloud instance %s with error %v", f.cloudInstanceID, err))
 	}
 	if resp == nil || resp.Payload == nil {
 		return nil, fmt.Errorf("failed to perform Create COS Image Operation for cloud instance %s", f.cloudInstanceID)
@@ -99,7 +99,7 @@ func (f *IBMPIImageClient) ExportImage(id string, body *models.ExportImage) (*mo
 		WithCloudInstanceID(f.cloudInstanceID).WithImageID(id).WithBody(body)
 	resp, err := f.session.Power.PCloudImages.PcloudV2ImagesExportPost(params, f.session.AuthInfo(f.cloudInstanceID))
 	if err != nil {
-		return nil, fmt.Errorf("failed to Export COS Image for image id %s with error %w", id, err)
+		return nil, ibmpisession.SDKFailWithAPIError(err, fmt.Sprintf("failed to Export COS Image for image id %s with error %v", id, err))
 	}
 	if resp == nil || resp.Payload == nil {
 		return nil, fmt.Errorf("failed to Export COS Image for image id %s", id)
@@ -114,7 +114,7 @@ func (f *IBMPIImageClient) Delete(id string) error {
 		WithCloudInstanceID(f.cloudInstanceID).WithImageID(id)
 	_, err := f.session.Power.PCloudImages.PcloudCloudinstancesImagesDelete(params, f.session.AuthInfo(f.cloudInstanceID))
 	if err != nil {
-		return fmt.Errorf("failed to Delete PI Image %s: %w", id, err)
+		return fmt.Errorf("failed to Delete PI Image %s: %v", id, err)
 	}
 	return nil
 }
@@ -126,7 +126,7 @@ func (f *IBMPIImageClient) GetStockImage(id string) (*models.Image, error) {
 		WithCloudInstanceID(f.cloudInstanceID).WithImageID(id)
 	resp, err := f.session.Power.PCloudImages.PcloudCloudinstancesStockimagesGet(params, f.session.AuthInfo(f.cloudInstanceID))
 	if err != nil {
-		return nil, fmt.Errorf("failed to Get PI Stock Image %s for cloud instance %s: %w", id, f.cloudInstanceID, err)
+		return nil, ibmpisession.SDKFailWithAPIError(err, fmt.Sprintf("failed to Get PI Stock Image %s for cloud instance %s: %v", id, f.cloudInstanceID, err))
 	}
 	if resp == nil || resp.Payload == nil {
 		return nil, fmt.Errorf("failed to Get PI Stock Image %s for cloud instance %s", id, f.cloudInstanceID)
@@ -143,7 +143,7 @@ func (f *IBMPIImageClient) GetAllStockImages(includeSAP bool, includeVTl bool) (
 		WithVtl(&includeVTl)
 	resp, err := f.session.Power.PCloudImages.PcloudCloudinstancesStockimagesGetall(params, f.session.AuthInfo(f.cloudInstanceID))
 	if err != nil {
-		return nil, fmt.Errorf("failed to get Stock Images with (SAP=%t, VTL=%t) for cloud instance %s: %w", includeSAP, includeVTl, f.cloudInstanceID, err)
+		return nil, ibmpisession.SDKFailWithAPIError(err, fmt.Sprintf("failed to get Stock Images with (SAP=%t, VTL=%t) for cloud instance %s: %v", includeSAP, includeVTl, f.cloudInstanceID, err))
 	}
 	if resp == nil || resp.Payload == nil {
 		return nil, fmt.Errorf("failed to get Stock Images with (SAP=%t, VTL=%t) for cloud instance %s", includeSAP, includeVTl, f.cloudInstanceID)

--- a/clients/instance/ibm-pi-instance.go
+++ b/clients/instance/ibm-pi-instance.go
@@ -29,7 +29,7 @@ func (f *IBMPIInstanceClient) Get(id string) (*models.PVMInstance, error) {
 		WithCloudInstanceID(f.cloudInstanceID).WithPvmInstanceID(id)
 	resp, err := f.session.Power.PCloudpVMInstances.PcloudPvminstancesGet(params, f.session.AuthInfo(f.cloudInstanceID))
 	if err != nil {
-		return nil, fmt.Errorf("failed to Get PVM Instance %s :%w", id, err)
+		return nil, ibmpisession.SDKFailWithAPIError(err, fmt.Sprintf("failed to Get PVM Instance %s :%v", id, err))
 	}
 	if resp == nil || resp.Payload == nil {
 		return nil, fmt.Errorf("failed to Get PVM Instance %s", id)
@@ -44,7 +44,7 @@ func (f *IBMPIInstanceClient) GetAll() (*models.PVMInstances, error) {
 		WithCloudInstanceID(f.cloudInstanceID)
 	resp, err := f.session.Power.PCloudpVMInstances.PcloudPvminstancesGetall(params, f.session.AuthInfo(f.cloudInstanceID))
 	if err != nil {
-		return nil, fmt.Errorf("failed to Get all PVM Instances of Power Instance %s :%w", f.cloudInstanceID, err)
+		return nil, ibmpisession.SDKFailWithAPIError(err, fmt.Sprintf("failed to Get all PVM Instances of Power Instance %s :%v", f.cloudInstanceID, err))
 	}
 	if resp == nil || resp.Payload == nil {
 		return nil, fmt.Errorf("failed to Get all PVM Instances of Power Instance %s", f.cloudInstanceID)
@@ -63,7 +63,7 @@ func (f *IBMPIInstanceClient) Create(body *models.PVMInstanceCreate) (*models.PV
 		WithCloudInstanceID(f.cloudInstanceID).WithBody(body)
 	postok, postcreated, postAccepted, err := f.session.Power.PCloudpVMInstances.PcloudPvminstancesPost(params, f.session.AuthInfo(f.cloudInstanceID))
 	if err != nil {
-		return nil, fmt.Errorf("failed to Create PVM Instance :%w", err)
+		return nil, ibmpisession.SDKFailWithAPIError(err, fmt.Sprintf("failed to Create PVM Instance :%v", err))
 	}
 	if postok != nil && len(postok.Payload) > 0 {
 		return &postok.Payload, nil
@@ -84,7 +84,7 @@ func (f *IBMPIInstanceClient) Delete(id string) error {
 		WithCloudInstanceID(f.cloudInstanceID).WithPvmInstanceID(id)
 	_, err := f.session.Power.PCloudpVMInstances.PcloudPvminstancesDelete(params, f.session.AuthInfo(f.cloudInstanceID))
 	if err != nil {
-		return fmt.Errorf("failed to Delete PVM Instance %s :%w", id, err)
+		return fmt.Errorf("failed to Delete PVM Instance %s :%v", id, err)
 	}
 	return nil
 }
@@ -100,7 +100,7 @@ func (f *IBMPIInstanceClient) Update(id string, body *models.PVMInstanceUpdate) 
 		WithCloudInstanceID(f.cloudInstanceID).WithPvmInstanceID(id).WithBody(body)
 	resp, err := f.session.Power.PCloudpVMInstances.PcloudPvminstancesPut(params, f.session.AuthInfo(f.cloudInstanceID))
 	if err != nil {
-		return nil, fmt.Errorf("failed to Update PVM Instance %s :%w", id, err)
+		return nil, ibmpisession.SDKFailWithAPIError(err, fmt.Sprintf("failed to Update PVM Instance %s :%v", id, err))
 	}
 	if resp == nil || resp.Payload == nil {
 		return nil, fmt.Errorf("failed to Update PVM Instance %s", id)
@@ -116,7 +116,7 @@ func (f *IBMPIInstanceClient) Action(id string, body *models.PVMInstanceAction) 
 		WithBody(body)
 	_, err := f.session.Power.PCloudpVMInstances.PcloudPvminstancesActionPost(params, f.session.AuthInfo(f.cloudInstanceID))
 	if err != nil {
-		return fmt.Errorf("failed to perform Action on PVM Instance %s :%w", id, err)
+		return fmt.Errorf("failed to perform Action on PVM Instance %s :%v", id, err)
 	}
 	return nil
 
@@ -129,7 +129,7 @@ func (f *IBMPIInstanceClient) PostConsoleURL(id string) (*models.PVMInstanceCons
 		WithCloudInstanceID(f.cloudInstanceID).WithPvmInstanceID(id)
 	postok, err := f.session.Power.PCloudpVMInstances.PcloudPvminstancesConsolePost(params, f.session.AuthInfo(f.cloudInstanceID))
 	if err != nil {
-		return nil, fmt.Errorf("failed to Generate the Console URL PVM Instance %s :%w", id, err)
+		return nil, ibmpisession.SDKFailWithAPIError(err, fmt.Sprintf("failed to Generate the Console URL PVM Instance %s :%v", id, err))
 	}
 	if postok == nil || postok.Payload == nil {
 		return nil, fmt.Errorf("failed to Generate the Console URL PVM Instance %s", id)
@@ -147,7 +147,7 @@ func (f *IBMPIInstanceClient) GetConsoleLanguages(id string) (*models.ConsoleLan
 		WithCloudInstanceID(f.cloudInstanceID).WithPvmInstanceID(id)
 	resp, err := f.session.Power.PCloudpVMInstances.PcloudPvminstancesConsoleGet(params, f.session.AuthInfo(f.cloudInstanceID))
 	if err != nil {
-		return nil, fmt.Errorf("failed to Get Console Languages for PVM Instance %s :%w", id, err)
+		return nil, ibmpisession.SDKFailWithAPIError(err, fmt.Sprintf("failed to Get Console Languages for PVM Instance %s :%v", id, err))
 	}
 	if resp == nil || resp.Payload == nil {
 		return nil, fmt.Errorf("failed to Get Console Languages for PVM Instance %s", id)
@@ -166,7 +166,7 @@ func (f *IBMPIInstanceClient) UpdateConsoleLanguage(id string, body *models.Cons
 		WithBody(body)
 	resp, err := f.session.Power.PCloudpVMInstances.PcloudPvminstancesConsolePut(params, f.session.AuthInfo(f.cloudInstanceID))
 	if err != nil {
-		return nil, fmt.Errorf("failed to Update Console Language for PVM Instance %s :%w", id, err)
+		return nil, ibmpisession.SDKFailWithAPIError(err, fmt.Sprintf("failed to Update Console Language for PVM Instance %s :%v", id, err))
 	}
 	if resp == nil || resp.Payload == nil {
 		return nil, fmt.Errorf("failed to Update Console Language for PVM Instance %s", id)
@@ -182,7 +182,7 @@ func (f *IBMPIInstanceClient) CaptureInstanceToImageCatalog(id string, body *mod
 		WithBody(body)
 	_, _, err := f.session.Power.PCloudpVMInstances.PcloudPvminstancesCapturePost(params, f.session.AuthInfo(f.cloudInstanceID))
 	if err != nil {
-		return fmt.Errorf("failed to Capture the PVM Instance %s: %w", id, err)
+		return fmt.Errorf("failed to Capture the PVM Instance %s: %v", id, err)
 	}
 	return nil
 
@@ -196,7 +196,7 @@ func (f *IBMPIInstanceClient) CaptureInstanceToImageCatalogV2(id string, body *m
 		WithBody(body)
 	resp, err := f.session.Power.PCloudpVMInstances.PcloudV2PvminstancesCapturePost(params, f.session.AuthInfo(f.cloudInstanceID))
 	if err != nil {
-		return nil, fmt.Errorf("failed to Capture the PVM Instance %s: %w", id, err)
+		return nil, ibmpisession.SDKFailWithAPIError(err, fmt.Sprintf("failed to Capture the PVM Instance %s: %v", id, err))
 	}
 	if resp == nil || resp.Payload == nil {
 		return nil, fmt.Errorf("failed to Capture the PVM Instance %s", id)
@@ -212,7 +212,7 @@ func (f *IBMPIInstanceClient) CreatePvmSnapShot(id string, body *models.Snapshot
 		WithBody(body)
 	snapshotpostaccepted, err := f.session.Power.PCloudpVMInstances.PcloudPvminstancesSnapshotsPost(params, f.session.AuthInfo(f.cloudInstanceID))
 	if err != nil {
-		return nil, fmt.Errorf("failed to Create the snapshot for the pvminstance %s: %w", id, err)
+		return nil, ibmpisession.SDKFailWithAPIError(err, fmt.Sprintf("failed to Create the snapshot for the pvminstance %s: %v", id, err))
 	}
 	if snapshotpostaccepted == nil || snapshotpostaccepted.Payload == nil {
 		return nil, fmt.Errorf("failed to Create the snapshot for the pvminstance %s", id)
@@ -228,7 +228,7 @@ func (f *IBMPIInstanceClient) CreateClone(id string, body *models.PVMInstanceClo
 		WithBody(body)
 	clonePost, err := f.session.Power.PCloudpVMInstances.PcloudPvminstancesClonePost(params, f.session.AuthInfo(f.cloudInstanceID))
 	if err != nil {
-		return nil, fmt.Errorf("failed to create the clone of the pvm instance %s: %w", id, err)
+		return nil, ibmpisession.SDKFailWithAPIError(err, fmt.Sprintf("failed to create the clone of the pvm instance %s: %v", id, err))
 	}
 	if clonePost == nil || clonePost.Payload == nil {
 		return nil, fmt.Errorf("failed to create the clone of the pvm instance %s", id)
@@ -243,7 +243,7 @@ func (f *IBMPIInstanceClient) GetSnapShotVM(id string) (*models.Snapshots, error
 		WithCloudInstanceID(f.cloudInstanceID).WithPvmInstanceID(id)
 	resp, err := f.session.Power.PCloudpVMInstances.PcloudPvminstancesSnapshotsGetall(params, f.session.AuthInfo(f.cloudInstanceID))
 	if err != nil {
-		return nil, fmt.Errorf("failed to Get the snapshot for the pvminstance %s: %w", id, err)
+		return nil, ibmpisession.SDKFailWithAPIError(err, fmt.Sprintf("failed to Get the snapshot for the pvminstance %s: %v", id, err))
 	}
 	if resp == nil || resp.Payload == nil {
 		return nil, fmt.Errorf("failed to Get the snapshot for the pvminstance %s", id)
@@ -261,7 +261,7 @@ func (f *IBMPIInstanceClient) RestoreSnapShotVM(id, snapshotid, restoreAction st
 		WithBody(body)
 	resp, err := f.session.Power.PCloudpVMInstances.PcloudPvminstancesSnapshotsRestorePost(params, f.session.AuthInfo(f.cloudInstanceID))
 	if err != nil {
-		return nil, fmt.Errorf("failed to restrore the snapshot for the pvminstance %s: %w", id, err)
+		return nil, ibmpisession.SDKFailWithAPIError(err, fmt.Sprintf("failed to restrore the snapshot for the pvminstance %s: %v", id, err))
 	}
 	if resp == nil || resp.Payload == nil {
 		return nil, fmt.Errorf("failed to restrore the snapshot for the pvminstance %s", id)
@@ -277,7 +277,7 @@ func (f *IBMPIInstanceClient) AddNetwork(id string, body *models.PVMInstanceAddN
 		WithBody(body)
 	resp, err := f.session.Power.PCloudpVMInstances.PcloudPvminstancesNetworksPost(params, f.session.AuthInfo(f.cloudInstanceID))
 	if err != nil {
-		return nil, fmt.Errorf("failed to attach the network to the pvminstanceid %s: %w", id, err)
+		return nil, ibmpisession.SDKFailWithAPIError(err, fmt.Sprintf("failed to attach the network to the pvminstanceid %s: %v", id, err))
 	}
 	if resp == nil || resp.Payload == nil {
 		return nil, fmt.Errorf("failed to attach the network to the pvminstanceid %s", id)
@@ -293,7 +293,7 @@ func (f *IBMPIInstanceClient) DeleteNetwork(id string, body *models.PVMInstanceR
 		WithBody(body)
 	_, err := f.session.Power.PCloudpVMInstances.PcloudPvminstancesNetworksDelete(params, f.session.AuthInfo(f.cloudInstanceID))
 	if err != nil {
-		return fmt.Errorf("failed to delete the network to the pvminstanceid %s: %w", id, err)
+		return fmt.Errorf("failed to delete the network to the pvminstanceid %s: %v", id, err)
 	}
 	return nil
 }

--- a/clients/instance/ibm-pi-job.go
+++ b/clients/instance/ibm-pi-job.go
@@ -31,7 +31,7 @@ func (f *IBMPIJobClient) Get(id string) (*models.Job, error) {
 		WithCloudInstanceID(f.cloudInstanceID).WithJobID(id)
 	resp, err := f.session.Power.PCloudJobs.PcloudCloudinstancesJobsGet(params, f.session.AuthInfo(f.cloudInstanceID))
 	if err != nil {
-		return nil, fmt.Errorf(errors.GetJobOperationFailed, id, err)
+		return nil, ibmpisession.SDKFailWithAPIError(err, fmt.Sprintf(errors.GetJobOperationFailed, id, err))
 	}
 	if resp == nil || resp.Payload == nil {
 		return nil, fmt.Errorf("failed to perform get Job operation for job id %s", id)
@@ -46,7 +46,7 @@ func (f *IBMPIJobClient) GetAll() (*models.Jobs, error) {
 		WithCloudInstanceID(f.cloudInstanceID)
 	resp, err := f.session.Power.PCloudJobs.PcloudCloudinstancesJobsGetall(params, f.session.AuthInfo(f.cloudInstanceID))
 	if err != nil {
-		return nil, fmt.Errorf(errors.GetAllJobsOperationFailed, err)
+		return nil, ibmpisession.SDKFailWithAPIError(err, fmt.Sprintf(errors.GetAllJobsOperationFailed, err))
 	}
 	if resp == nil || resp.Payload == nil {
 		return nil, fmt.Errorf("failed to perform get all jobs")

--- a/clients/instance/ibm-pi-key.go
+++ b/clients/instance/ibm-pi-key.go
@@ -32,7 +32,7 @@ func (f *IBMPIKeyClient) Get(id string) (*models.SSHKey, error) {
 		WithTenantID(tenantid).WithSshkeyName(id)
 	resp, err := f.session.Power.PCloudTenantsSSHKeys.PcloudTenantsSshkeysGet(params, f.session.AuthInfo(f.cloudInstanceID))
 	if err != nil {
-		return nil, fmt.Errorf(errors.GetPIKeyOperationFailed, id, err)
+		return nil, ibmpisession.SDKFailWithAPIError(err, fmt.Sprintf(errors.GetPIKeyOperationFailed, id, err))
 	}
 	if resp == nil || resp.Payload == nil {
 		return nil, fmt.Errorf("failed to Get PI Key %s", id)
@@ -48,7 +48,7 @@ func (f *IBMPIKeyClient) GetAll() (*models.SSHKeys, error) {
 		WithTenantID(tenantid)
 	resp, err := f.session.Power.PCloudTenantsSSHKeys.PcloudTenantsSshkeysGetall(params, f.session.AuthInfo(f.cloudInstanceID))
 	if err != nil {
-		return nil, fmt.Errorf("failed to Get all PI Keys: %w", err)
+		return nil, ibmpisession.SDKFailWithAPIError(err, fmt.Sprintf("failed to Get all PI Keys: %v", err))
 	}
 	if resp == nil || resp.Payload == nil {
 		return nil, fmt.Errorf("failed to Get all PI Keys")
@@ -64,7 +64,7 @@ func (f *IBMPIKeyClient) Create(body *models.SSHKey) (*models.SSHKey, error) {
 		WithTenantID(tenantid).WithBody(body)
 	postok, postcreated, err := f.session.Power.PCloudTenantsSSHKeys.PcloudTenantsSshkeysPost(params, f.session.AuthInfo(f.cloudInstanceID))
 	if err != nil {
-		return nil, fmt.Errorf(errors.CreatePIKeyOperationFailed, err)
+		return nil, ibmpisession.SDKFailWithAPIError(err, fmt.Sprintf(errors.CreatePIKeyOperationFailed, err))
 	}
 	if postok != nil && postok.Payload != nil {
 		return postok.Payload, nil

--- a/clients/instance/ibm-pi-network.go
+++ b/clients/instance/ibm-pi-network.go
@@ -31,7 +31,7 @@ func (f *IBMPINetworkClient) Get(id string) (*models.Network, error) {
 		WithCloudInstanceID(f.cloudInstanceID).WithNetworkID(id)
 	resp, err := f.session.Power.PCloudNetworks.PcloudNetworksGet(params, f.session.AuthInfo(f.cloudInstanceID))
 	if err != nil {
-		return nil, fmt.Errorf(errors.GetNetworkOperationFailed, id, err)
+		return nil, ibmpisession.SDKFailWithAPIError(err, fmt.Sprintf(errors.GetNetworkOperationFailed, id, err))
 	}
 	if resp == nil || resp.Payload == nil {
 		return nil, fmt.Errorf("failed to Get Network %s", id)
@@ -46,7 +46,7 @@ func (f *IBMPINetworkClient) GetAll() (*models.Networks, error) {
 		WithCloudInstanceID(f.cloudInstanceID)
 	resp, err := f.session.Power.PCloudNetworks.PcloudNetworksGetall(params, f.session.AuthInfo(f.cloudInstanceID))
 	if err != nil {
-		return nil, fmt.Errorf("failed to Get Network for cloud instance %s with error %w", f.cloudInstanceID, err)
+		return nil, ibmpisession.SDKFailWithAPIError(err, fmt.Sprintf("failed to Get Network for cloud instance %s with error %v", f.cloudInstanceID, err))
 	}
 	if resp == nil || resp.Payload == nil {
 		return nil, fmt.Errorf("failed to Get Network for cloud instance %s", f.cloudInstanceID)
@@ -76,7 +76,7 @@ func (f *IBMPINetworkClient) Create(body *models.NetworkCreate) (*models.Network
 		WithCloudInstanceID(f.cloudInstanceID).WithBody(body)
 	postok, postcreated, err := f.session.Power.PCloudNetworks.PcloudNetworksPost(params, f.session.AuthInfo(f.cloudInstanceID))
 	if err != nil {
-		return nil, fmt.Errorf(errors.CreateNetworkOperationFailed, body.Name, err)
+		return nil, ibmpisession.SDKFailWithAPIError(err, fmt.Sprintf(errors.CreateNetworkOperationFailed, body.Name, err))
 	}
 	if postok != nil && postok.Payload != nil {
 		return postok.Payload, nil
@@ -95,7 +95,7 @@ func (f *IBMPINetworkClient) Update(id string, body *models.NetworkUpdate) (*mod
 		WithBody(body)
 	resp, err := f.session.Power.PCloudNetworks.PcloudNetworksPut(params, f.session.AuthInfo(f.cloudInstanceID))
 	if err != nil {
-		return nil, fmt.Errorf("failed to perform Update Network Operation for Network %s with error %w", id, err)
+		return nil, ibmpisession.SDKFailWithAPIError(err, fmt.Sprintf("failed to perform Update Network Operation for Network %s with error %v", id, err))
 	}
 	if resp == nil || resp.Payload == nil {
 		return nil, fmt.Errorf("failed to perform Update Network Operation for Network %s", id)
@@ -111,7 +111,7 @@ func (f *IBMPINetworkClient) GetAllPublic() (*models.Networks, error) {
 		WithCloudInstanceID(f.cloudInstanceID).WithFilter(&filterQuery)
 	resp, err := f.session.Power.PCloudNetworks.PcloudNetworksGetall(params, f.session.AuthInfo(f.cloudInstanceID))
 	if err != nil {
-		return nil, fmt.Errorf("failed to Get all Public Networks for cloud instance %s: %w", f.cloudInstanceID, err)
+		return nil, ibmpisession.SDKFailWithAPIError(err, fmt.Sprintf("failed to Get all Public Networks for cloud instance %s: %v", f.cloudInstanceID, err))
 	}
 	if resp == nil || resp.Payload == nil {
 		return nil, fmt.Errorf("failed to Get all Public Networks for cloud instance %s", f.cloudInstanceID)
@@ -126,7 +126,7 @@ func (f *IBMPINetworkClient) Delete(id string) error {
 		WithCloudInstanceID(f.cloudInstanceID).WithNetworkID(id)
 	_, err := f.session.Power.PCloudNetworks.PcloudNetworksDelete(params, f.session.AuthInfo(f.cloudInstanceID))
 	if err != nil {
-		return fmt.Errorf("failed to Delete PI Network %s: %w", id, err)
+		return fmt.Errorf("failed to Delete PI Network %s: %v", id, err)
 	}
 	return nil
 }
@@ -138,7 +138,7 @@ func (f *IBMPINetworkClient) GetAllPorts(id string) (*models.NetworkPorts, error
 		WithCloudInstanceID(f.cloudInstanceID).WithNetworkID(id)
 	resp, err := f.session.Power.PCloudNetworks.PcloudNetworksPortsGetall(params, f.session.AuthInfo(f.cloudInstanceID))
 	if err != nil {
-		return nil, fmt.Errorf("failed to Get all Network Ports for Network %s: %w", id, err)
+		return nil, ibmpisession.SDKFailWithAPIError(err, fmt.Sprintf("failed to Get all Network Ports for Network %s: %v", id, err))
 	}
 	if resp == nil || resp.Payload == nil {
 		return nil, fmt.Errorf("failed to Get all Network Ports for Network %s", id)
@@ -155,7 +155,7 @@ func (f *IBMPINetworkClient) GetPort(id string, networkPortID string) (*models.N
 	resp, err := f.session.Power.PCloudNetworks.PcloudNetworksPortsGet(params, f.session.AuthInfo(f.cloudInstanceID))
 
 	if err != nil {
-		return nil, fmt.Errorf("failed to Get PI Network Port %s for Network %s: %w", networkPortID, id, err)
+		return nil, ibmpisession.SDKFailWithAPIError(err, fmt.Sprintf("failed to Get PI Network Port %s for Network %s: %v", networkPortID, id, err))
 	}
 	if resp == nil || resp.Payload == nil {
 		return nil, fmt.Errorf("failed to Get PI Network Port %s for Network %s", networkPortID, id)
@@ -171,7 +171,7 @@ func (f *IBMPINetworkClient) CreatePort(id string, body *models.NetworkPortCreat
 		WithBody(body)
 	resp, err := f.session.Power.PCloudNetworks.PcloudNetworksPortsPost(params, f.session.AuthInfo(f.cloudInstanceID))
 	if err != nil {
-		return nil, fmt.Errorf(errors.CreateNetworkPortOperationFailed, id, err)
+		return nil, ibmpisession.SDKFailWithAPIError(err, fmt.Sprintf(errors.CreateNetworkPortOperationFailed, id, err))
 	}
 	if resp == nil || resp.Payload == nil {
 		return nil, fmt.Errorf("failed to perform Create Network Port Operation for Network %s", id)
@@ -187,7 +187,7 @@ func (f *IBMPINetworkClient) DeletePort(id string, networkPortID string) error {
 		WithPortID(networkPortID)
 	_, err := f.session.Power.PCloudNetworks.PcloudNetworksPortsDelete(params, f.session.AuthInfo(f.cloudInstanceID))
 	if err != nil {
-		return fmt.Errorf("failed to delete the network port %s for network %s with error %w", networkPortID, id, err)
+		return fmt.Errorf("failed to delete the network port %s for network %s with error %v", networkPortID, id, err)
 	}
 	return nil
 }
@@ -200,7 +200,7 @@ func (f *IBMPINetworkClient) UpdatePort(id, networkPortID string, body *models.N
 		WithPortID(networkPortID).WithBody(body)
 	resp, err := f.session.Power.PCloudNetworks.PcloudNetworksPortsPut(params, f.session.AuthInfo(f.cloudInstanceID))
 	if err != nil {
-		return nil, fmt.Errorf("failed to update the port %s and Network %s with error %w", networkPortID, id, err)
+		return nil, ibmpisession.SDKFailWithAPIError(err, fmt.Sprintf("failed to update the port %s and Network %s with error %v", networkPortID, id, err))
 	}
 	if resp == nil || resp.Payload == nil {
 		return nil, fmt.Errorf("failed to update the port %s and Network %s", networkPortID, id)

--- a/clients/instance/ibm-pi-placement-groups.go
+++ b/clients/instance/ibm-pi-placement-groups.go
@@ -12,7 +12,7 @@ import (
 	"github.com/IBM-Cloud/power-go-client/power/models"
 )
 
-//IBMPIPlacementGroupClient
+// IBMPIPlacementGroupClient
 type IBMPIPlacementGroupClient struct {
 	IBMPIClient
 }
@@ -31,7 +31,7 @@ func (f *IBMPIPlacementGroupClient) Get(id string) (*models.PlacementGroup, erro
 		WithCloudInstanceID(f.cloudInstanceID).WithPlacementGroupID(id)
 	resp, err := f.session.Power.PCloudPlacementGroups.PcloudPlacementgroupsGet(params, f.session.AuthInfo(f.cloudInstanceID))
 	if err != nil {
-		return nil, fmt.Errorf(errors.GetPlacementGroupOperationFailed, id, err)
+		return nil, ibmpisession.SDKFailWithAPIError(err, fmt.Sprintf(errors.GetPlacementGroupOperationFailed, id, err))
 	}
 	if resp == nil || resp.Payload == nil {
 		return nil, fmt.Errorf("failed to Get Placement Group %s", id)
@@ -46,7 +46,7 @@ func (f *IBMPIPlacementGroupClient) GetAll() (*models.PlacementGroups, error) {
 		WithCloudInstanceID(f.cloudInstanceID)
 	resp, err := f.session.Power.PCloudPlacementGroups.PcloudPlacementgroupsGetall(params, f.session.AuthInfo(f.cloudInstanceID))
 	if err != nil {
-		return nil, fmt.Errorf("failed to Get All Placement Groups: %w", err)
+		return nil, ibmpisession.SDKFailWithAPIError(err, fmt.Sprintf("failed to Get All Placement Groups: %v", err))
 	}
 	if resp == nil || resp.Payload == nil {
 		return nil, fmt.Errorf("failed to Get all Placement Groups")
@@ -61,7 +61,7 @@ func (f *IBMPIPlacementGroupClient) Create(body *models.PlacementGroupCreate) (*
 		WithCloudInstanceID(f.cloudInstanceID).WithBody(body)
 	postok, err := f.session.Power.PCloudPlacementGroups.PcloudPlacementgroupsPost(params, f.session.AuthInfo(f.cloudInstanceID))
 	if err != nil {
-		return nil, fmt.Errorf(errors.CreatePlacementGroupOperationFailed, f.cloudInstanceID, err)
+		return nil, ibmpisession.SDKFailWithAPIError(err, fmt.Sprintf(errors.CreatePlacementGroupOperationFailed, f.cloudInstanceID, err))
 	}
 	if postok == nil || postok.Payload == nil {
 		return nil, fmt.Errorf("failed to Create Placement Group")
@@ -89,7 +89,7 @@ func (f *IBMPIPlacementGroupClient) AddMember(id string, body *models.PlacementG
 		WithBody(body)
 	postok, err := f.session.Power.PCloudPlacementGroups.PcloudPlacementgroupsMembersPost(params, f.session.AuthInfo(f.cloudInstanceID))
 	if err != nil {
-		return nil, fmt.Errorf(errors.AddMemberPlacementGroupOperationFailed, *body.ID, id, err)
+		return nil, ibmpisession.SDKFailWithAPIError(err, fmt.Sprintf(errors.AddMemberPlacementGroupOperationFailed, *body.ID, id, err))
 	}
 	if postok == nil || postok.Payload == nil {
 		return nil, fmt.Errorf("failed to Add Member for instance %s and placement group %s", *body.ID, id)
@@ -105,7 +105,7 @@ func (f *IBMPIPlacementGroupClient) DeleteMember(id string, body *models.Placeme
 		WithBody(body)
 	delok, err := f.session.Power.PCloudPlacementGroups.PcloudPlacementgroupsMembersDelete(params, f.session.AuthInfo(f.cloudInstanceID))
 	if err != nil {
-		return nil, fmt.Errorf(errors.DeleteMemberPlacementGroupOperationFailed, *body.ID, id, err)
+		return nil, ibmpisession.SDKFailWithAPIError(err, fmt.Sprintf(errors.DeleteMemberPlacementGroupOperationFailed, *body.ID, id, err))
 	}
 	if delok == nil || delok.Payload == nil {
 		return nil, fmt.Errorf("failed to Delete Member for instance %s and placement group %s", *body.ID, id)

--- a/clients/instance/ibm-pi-sap-instance.go
+++ b/clients/instance/ibm-pi-sap-instance.go
@@ -32,7 +32,7 @@ func (f *IBMPISAPInstanceClient) Create(body *models.SAPCreate) (*models.PVMInst
 		WithCloudInstanceID(f.cloudInstanceID).WithBody(body)
 	postok, postcreated, postAccepted, err := f.session.Power.PCloudsap.PcloudSapPost(params, f.session.AuthInfo(f.cloudInstanceID))
 	if err != nil {
-		return nil, fmt.Errorf("failed to Create SAP Instance: %w", err)
+		return nil, ibmpisession.SDKFailWithAPIError(err, fmt.Sprintf("failed to Create SAP Instance: %v", err))
 	}
 	if postok != nil && len(postok.Payload) > 0 {
 		return &postok.Payload, nil
@@ -56,7 +56,7 @@ func (f *IBMPISAPInstanceClient) GetSAPProfile(id string) (*models.SAPProfile, e
 		WithCloudInstanceID(f.cloudInstanceID).WithSapProfileID(id)
 	resp, err := f.session.Power.PCloudsap.PcloudSapGet(params, f.session.AuthInfo(f.cloudInstanceID))
 	if err != nil {
-		return nil, fmt.Errorf("failed to get sap profile %s : %w", id, err)
+		return nil, ibmpisession.SDKFailWithAPIError(err, fmt.Sprintf("failed to get sap profile %s : %v", id, err))
 	}
 	if resp == nil || resp.Payload == nil {
 		return nil, fmt.Errorf("failed to get sap profile %s", id)
@@ -74,7 +74,7 @@ func (f *IBMPISAPInstanceClient) GetAllSAPProfiles(cloudInstanceID string) (*mod
 		WithCloudInstanceID(f.cloudInstanceID)
 	resp, err := f.session.Power.PCloudsap.PcloudSapGetall(params, f.session.AuthInfo(f.cloudInstanceID))
 	if err != nil {
-		return nil, fmt.Errorf("failed to get all sap profiles for power instance %s: %w", cloudInstanceID, err)
+		return nil, ibmpisession.SDKFailWithAPIError(err, fmt.Sprintf("failed to get all sap profiles for power instance %s: %v", cloudInstanceID, err))
 	}
 	if resp == nil || resp.Payload == nil {
 		return nil, fmt.Errorf("failed to get all sap profiles for power instance %s", cloudInstanceID)

--- a/clients/instance/ibm-pi-shared-processor-pool.go
+++ b/clients/instance/ibm-pi-shared-processor-pool.go
@@ -34,7 +34,7 @@ func (f *IBMPISharedProcessorPoolClient) Get(id string) (*models.SharedProcessor
 		WithCloudInstanceID(f.cloudInstanceID).WithSharedProcessorPoolID(id)
 	resp, err := f.session.Power.PCloudSharedProcessorPools.PcloudSharedprocessorpoolsGet(params, f.session.AuthInfo(f.cloudInstanceID))
 	if err != nil {
-		return nil, fmt.Errorf(errors.GetSharedProcessorPoolOperationFailed, id, err)
+		return nil, ibmpisession.SDKFailWithAPIError(err, fmt.Sprintf(errors.GetSharedProcessorPoolOperationFailed, id, err))
 	}
 	if resp == nil || resp.Payload == nil {
 		return nil, fmt.Errorf("failed to Get Shared Processor Pool %s", id)
@@ -52,7 +52,7 @@ func (f *IBMPISharedProcessorPoolClient) GetAll() (*models.SharedProcessorPools,
 		WithCloudInstanceID(f.cloudInstanceID)
 	resp, err := f.session.Power.PCloudSharedProcessorPools.PcloudSharedprocessorpoolsGetall(params, f.session.AuthInfo(f.cloudInstanceID))
 	if err != nil {
-		return nil, fmt.Errorf("failed to Get All Shared Processor Pools: %w", err)
+		return nil, ibmpisession.SDKFailWithAPIError(err, fmt.Sprintf("failed to Get All Shared Processor Pools: %v", err))
 	}
 	if resp == nil || resp.Payload == nil {
 		return nil, fmt.Errorf("failed to Get all Shared Processor Pools")
@@ -70,7 +70,7 @@ func (f *IBMPISharedProcessorPoolClient) Create(body *models.SharedProcessorPool
 		WithCloudInstanceID(f.cloudInstanceID).WithBody(body)
 	postok, err := f.session.Power.PCloudSharedProcessorPools.PcloudSharedprocessorpoolsPost(params, f.session.AuthInfo(f.cloudInstanceID))
 	if err != nil {
-		return nil, fmt.Errorf(errors.CreateSharedProcessorPoolOperationFailed, f.cloudInstanceID, err)
+		return nil, ibmpisession.SDKFailWithAPIError(err, fmt.Sprintf(errors.CreateSharedProcessorPoolOperationFailed, f.cloudInstanceID, err))
 	}
 	if postok == nil || postok.Payload == nil {
 		return nil, fmt.Errorf("failed to Create a Shared Processor Pool")
@@ -103,7 +103,7 @@ func (f *IBMPISharedProcessorPoolClient) Update(id string, body *models.SharedPr
 		WithCloudInstanceID(f.cloudInstanceID).WithBody(body).WithSharedProcessorPoolID(id)
 	resp, err := f.session.Power.PCloudSharedProcessorPools.PcloudSharedprocessorpoolsPut(params, f.session.AuthInfo(f.cloudInstanceID))
 	if err != nil {
-		return nil, fmt.Errorf(errors.UpdateSharedProcessorPoolOperationFailed, id, err)
+		return nil, ibmpisession.SDKFailWithAPIError(err, fmt.Sprintf(errors.UpdateSharedProcessorPoolOperationFailed, id, err))
 	}
 	if resp == nil || resp.Payload == nil {
 		return nil, fmt.Errorf("failed to Update Shared Processor Pool %s", id)

--- a/clients/instance/ibm-pi-snapshot.go
+++ b/clients/instance/ibm-pi-snapshot.go
@@ -30,7 +30,7 @@ func (f *IBMPISnapshotClient) Get(id string) (*models.Snapshot, error) {
 		WithCloudInstanceID(f.cloudInstanceID).WithSnapshotID(id)
 	resp, err := f.session.Power.PCloudSnapshots.PcloudCloudinstancesSnapshotsGet(params, f.session.AuthInfo(f.cloudInstanceID))
 	if err != nil {
-		return nil, fmt.Errorf("failed to Get PI Snapshot %s: %w", id, err)
+		return nil, ibmpisession.SDKFailWithAPIError(err, fmt.Sprintf("failed to Get PI Snapshot %s: %v", id, err))
 	}
 	if resp == nil || resp.Payload == nil {
 		return nil, fmt.Errorf("failed to Get PI Snapshot %s", id)
@@ -45,7 +45,7 @@ func (f *IBMPISnapshotClient) Delete(id string) error {
 		WithCloudInstanceID(f.cloudInstanceID).WithSnapshotID(id)
 	_, err := f.session.Power.PCloudSnapshots.PcloudCloudinstancesSnapshotsDelete(params, f.session.AuthInfo(f.cloudInstanceID))
 	if err != nil {
-		return fmt.Errorf("failed to Delete PI Snapshot %s: %w", id, err)
+		return fmt.Errorf("failed to Delete PI Snapshot %s: %v", id, err)
 	}
 	return nil
 }
@@ -58,7 +58,7 @@ func (f *IBMPISnapshotClient) Update(id string, body *models.SnapshotUpdate) (mo
 		WithBody(body)
 	resp, err := f.session.Power.PCloudSnapshots.PcloudCloudinstancesSnapshotsPut(params, f.session.AuthInfo(f.cloudInstanceID))
 	if err != nil {
-		return nil, fmt.Errorf("failed to Update PI Snapshot %s: %w", id, err)
+		return nil, ibmpisession.SDKFailWithAPIError(err, fmt.Sprintf("failed to Update PI Snapshot %s: %v", id, err))
 	}
 	if resp == nil || resp.Payload == nil {
 		return nil, fmt.Errorf("failed to Update PI Snapshot %s", id)
@@ -73,7 +73,7 @@ func (f *IBMPISnapshotClient) GetAll() (*models.Snapshots, error) {
 		WithCloudInstanceID(f.cloudInstanceID)
 	resp, err := f.session.Power.PCloudSnapshots.PcloudCloudinstancesSnapshotsGetall(params, f.session.AuthInfo(f.cloudInstanceID))
 	if err != nil {
-		return nil, fmt.Errorf("failed to Get all PI Snapshots: %w", err)
+		return nil, ibmpisession.SDKFailWithAPIError(err, fmt.Sprintf("failed to Get all PI Snapshots: %v", err))
 	}
 	if resp == nil || resp.Payload == nil {
 		return nil, fmt.Errorf("failed to Get all PI Snapshots")
@@ -89,7 +89,7 @@ func (f *IBMPISnapshotClient) Create(instanceID, snapshotID, restoreFailAction s
 		WithSnapshotID(snapshotID).WithRestoreFailAction(&restoreFailAction)
 	resp, err := f.session.Power.PCloudpVMInstances.PcloudPvminstancesSnapshotsRestorePost(params, f.session.AuthInfo(f.cloudInstanceID))
 	if err != nil {
-		return nil, fmt.Errorf("failed to restore PI Snapshot %s of the instance %s: %w", snapshotID, instanceID, err)
+		return nil, ibmpisession.SDKFailWithAPIError(err, fmt.Sprintf("failed to restore PI Snapshot %s of the instance %s: %v", snapshotID, instanceID, err))
 	}
 	if resp == nil || resp.Payload == nil {
 		return nil, fmt.Errorf("failed to restore PI Snapshot %s of the instance %s", snapshotID, instanceID)

--- a/clients/instance/ibm-pi-spp-placement-groups.go
+++ b/clients/instance/ibm-pi-spp-placement-groups.go
@@ -34,7 +34,7 @@ func (f *IBMPISPPPlacementGroupClient) Get(id string) (*models.SPPPlacementGroup
 		WithCloudInstanceID(f.cloudInstanceID).WithSppPlacementGroupID(id)
 	resp, err := f.session.Power.PCloudsppPlacementGroups.PcloudSppplacementgroupsGet(params, f.session.AuthInfo(f.cloudInstanceID))
 	if err != nil {
-		return nil, fmt.Errorf(errors.GetSPPPlacementGroupOperationFailed, id, err)
+		return nil, ibmpisession.SDKFailWithAPIError(err, fmt.Sprintf(errors.GetSPPPlacementGroupOperationFailed, id, err))
 	}
 	if resp == nil || resp.Payload == nil {
 		return nil, fmt.Errorf("failed to Get Shared Processor Pool Placement Group %s", id)
@@ -52,7 +52,7 @@ func (f *IBMPISPPPlacementGroupClient) GetAll() (*models.SPPPlacementGroups, err
 		WithCloudInstanceID(f.cloudInstanceID)
 	resp, err := f.session.Power.PCloudsppPlacementGroups.PcloudSppplacementgroupsGetall(params, f.session.AuthInfo(f.cloudInstanceID))
 	if err != nil {
-		return nil, fmt.Errorf("failed to Get All Shared Processor Pool Placement Groups: %w", err)
+		return nil, ibmpisession.SDKFailWithAPIError(err, fmt.Sprintf("failed to Get All Shared Processor Pool Placement Groups: %v", err))
 	}
 	if resp == nil || resp.Payload == nil {
 		return nil, fmt.Errorf("failed to Get all Shared Processor Pool Placement Groups")
@@ -70,7 +70,7 @@ func (f *IBMPISPPPlacementGroupClient) Create(body *models.SPPPlacementGroupCrea
 		WithCloudInstanceID(f.cloudInstanceID).WithBody(body)
 	postok, err := f.session.Power.PCloudsppPlacementGroups.PcloudSppplacementgroupsPost(params, f.session.AuthInfo(f.cloudInstanceID))
 	if err != nil {
-		return nil, fmt.Errorf(errors.CreateSPPPlacementGroupOperationFailed, f.cloudInstanceID, err)
+		return nil, ibmpisession.SDKFailWithAPIError(err, fmt.Sprintf(errors.CreateSPPPlacementGroupOperationFailed, f.cloudInstanceID, err))
 	}
 	if postok == nil || postok.Payload == nil {
 		return nil, fmt.Errorf("failed to Create Shared Processor Pool Placement Group")
@@ -104,7 +104,7 @@ func (f *IBMPISPPPlacementGroupClient) AddMember(id string, sppID string) (*mode
 		WithSharedProcessorPoolID(sppID)
 	postok, err := f.session.Power.PCloudsppPlacementGroups.PcloudSppplacementgroupsMembersPost(params, f.session.AuthInfo(f.cloudInstanceID))
 	if err != nil {
-		return nil, fmt.Errorf(errors.AddMemberSPPPlacementGroupOperationFailed, sppID, id, err)
+		return nil, ibmpisession.SDKFailWithAPIError(err, fmt.Sprintf(errors.AddMemberSPPPlacementGroupOperationFailed, sppID, id, err))
 	}
 	if postok == nil || postok.Payload == nil {
 		return nil, fmt.Errorf("failed to Add Member for pool %s and shared processor pool placement group %s", sppID, id)
@@ -123,7 +123,7 @@ func (f *IBMPISPPPlacementGroupClient) DeleteMember(id string, sppID string) (*m
 		WithSharedProcessorPoolID(sppID)
 	delok, err := f.session.Power.PCloudsppPlacementGroups.PcloudSppplacementgroupsMembersDelete(params, f.session.AuthInfo(f.cloudInstanceID))
 	if err != nil {
-		return nil, fmt.Errorf(errors.DeleteMemberSPPPlacementGroupOperationFailed, sppID, id, err)
+		return nil, ibmpisession.SDKFailWithAPIError(err, fmt.Sprintf(errors.DeleteMemberSPPPlacementGroupOperationFailed, sppID, id, err))
 	}
 	if delok == nil || delok.Payload == nil {
 		return nil, fmt.Errorf("failed to Delete Member for pool %s and  shared processor pool placement group %s", sppID, id)

--- a/clients/instance/ibm-pi-storage-capacity.go
+++ b/clients/instance/ibm-pi-storage-capacity.go
@@ -29,7 +29,7 @@ func (f *IBMPIStorageCapacityClient) GetAllStoragePoolsCapacity() (*models.Stora
 		WithCloudInstanceID(f.cloudInstanceID)
 	resp, err := f.session.Power.PCloudStorageCapacity.PcloudStoragecapacityPoolsGetall(params, f.session.AuthInfo(f.cloudInstanceID))
 	if err != nil {
-		return nil, fmt.Errorf("failed to get the capacity for all storage pools: %w", err)
+		return nil, ibmpisession.SDKFailWithAPIError(err, fmt.Sprintf("failed to get the capacity for all storage pools: %v", err))
 	}
 	if resp == nil || resp.Payload == nil {
 		return nil, fmt.Errorf("failed to get the capacity for all storage pools")
@@ -44,7 +44,7 @@ func (f *IBMPIStorageCapacityClient) GetStoragePoolCapacity(storagePool string) 
 		WithCloudInstanceID(f.cloudInstanceID).WithStoragePoolName(storagePool)
 	resp, err := f.session.Power.PCloudStorageCapacity.PcloudStoragecapacityPoolsGet(params, f.session.AuthInfo(f.cloudInstanceID))
 	if err != nil {
-		return nil, fmt.Errorf("failed to get the capacity for storage pool %s: %w", storagePool, err)
+		return nil, ibmpisession.SDKFailWithAPIError(err, fmt.Sprintf("failed to get the capacity for storage pool %s: %v", storagePool, err))
 	}
 	if resp == nil || resp.Payload == nil {
 		return nil, fmt.Errorf("failed to get the capacity for storage pool %s", storagePool)
@@ -59,7 +59,7 @@ func (f *IBMPIStorageCapacityClient) GetStorageTypeCapacity(storageType string) 
 		WithCloudInstanceID(f.cloudInstanceID).WithStorageTypeName(storageType)
 	resp, err := f.session.Power.PCloudStorageCapacity.PcloudStoragecapacityTypesGet(params, f.session.AuthInfo(f.cloudInstanceID))
 	if err != nil {
-		return nil, fmt.Errorf("failed to get the capacity for storage type %s: %w", storageType, err)
+		return nil, ibmpisession.SDKFailWithAPIError(err, fmt.Sprintf("failed to get the capacity for storage type %s: %v", storageType, err))
 	}
 	if resp == nil || resp.Payload == nil {
 		return nil, fmt.Errorf("failed to get the capacity for storage type %s", storageType)
@@ -74,7 +74,7 @@ func (f *IBMPIStorageCapacityClient) GetAllStorageTypesCapacity() (*models.Stora
 		WithCloudInstanceID(f.cloudInstanceID)
 	resp, err := f.session.Power.PCloudStorageCapacity.PcloudStoragecapacityTypesGetall(params, f.session.AuthInfo(f.cloudInstanceID))
 	if err != nil {
-		return nil, fmt.Errorf("failed to get the capacity for all storage types %w", err)
+		return nil, ibmpisession.SDKFailWithAPIError(err, fmt.Sprintf("failed to get the capacity for all storage types %v", err))
 	}
 	if resp == nil || resp.Payload == nil {
 		return nil, fmt.Errorf("failed to get the capacity for all storage types")

--- a/clients/instance/ibm-pi-system-pools.go
+++ b/clients/instance/ibm-pi-system-pools.go
@@ -24,7 +24,7 @@ func NewIBMPISystemPoolClient(ctx context.Context, sess *ibmpisession.IBMPISessi
 	}
 }
 
-//Get the System Pools
+// Get the System Pools
 // Deprecated: Use GetSystemPools()
 func (f *IBMPISystemPoolClient) Get(id string) (models.SystemPools, error) {
 	params := p_cloud_system_pools.NewPcloudSystempoolsGetParams().
@@ -32,7 +32,7 @@ func (f *IBMPISystemPoolClient) Get(id string) (models.SystemPools, error) {
 		WithCloudInstanceID(id)
 	resp, err := f.session.Power.PCloudSystemPools.PcloudSystempoolsGet(params, f.session.AuthInfo(f.cloudInstanceID))
 	if err != nil {
-		return nil, fmt.Errorf(errors.GetSystemPoolsOperationFailed, id, err)
+		return nil, ibmpisession.SDKFailWithAPIError(err, fmt.Sprintf(errors.GetSystemPoolsOperationFailed, id, err))
 	}
 	if resp == nil || resp.Payload == nil {
 		return nil, fmt.Errorf("failed to perform Get System Pools Operation for cloud instance id %s", id)
@@ -47,7 +47,7 @@ func (f *IBMPISystemPoolClient) GetSystemPools() (models.SystemPools, error) {
 		WithCloudInstanceID(f.cloudInstanceID)
 	resp, err := f.session.Power.PCloudSystemPools.PcloudSystempoolsGet(params, f.session.AuthInfo(f.cloudInstanceID))
 	if err != nil {
-		return nil, fmt.Errorf(errors.GetSystemPoolsOperationFailed, f.cloudInstanceID, err)
+		return nil, ibmpisession.SDKFailWithAPIError(err, fmt.Sprintf(errors.GetSystemPoolsOperationFailed, f.cloudInstanceID, err))
 	}
 	if resp == nil || resp.Payload == nil {
 		return nil, fmt.Errorf("failed to perform Get System Pools Operation for cloud instance id %s", f.cloudInstanceID)

--- a/clients/instance/ibm-pi-tenant.go
+++ b/clients/instance/ibm-pi-tenant.go
@@ -29,7 +29,7 @@ func (f *IBMPITenantClient) Get(tenantid string) (*models.Tenant, error) {
 		WithTenantID(tenantid)
 	resp, err := f.session.Power.PCloudTenants.PcloudTenantsGet(params, f.session.AuthInfo(f.cloudInstanceID))
 	if err != nil {
-		return nil, fmt.Errorf("failed to get tenant %s with error %w", tenantid, err)
+		return nil, ibmpisession.SDKFailWithAPIError(err, fmt.Sprintf("failed to get tenant %s with error %v", tenantid, err))
 	}
 	if resp == nil || resp.Payload == nil {
 		return nil, fmt.Errorf("failed to get tenant %s", tenantid)
@@ -44,7 +44,7 @@ func (f *IBMPITenantClient) GetSelfTenant() (*models.Tenant, error) {
 		WithTenantID(f.session.Options.UserAccount)
 	resp, err := f.session.Power.PCloudTenants.PcloudTenantsGet(params, f.session.AuthInfo(f.cloudInstanceID))
 	if err != nil {
-		return nil, fmt.Errorf("failed to get self tenant with error %w", err)
+		return nil, ibmpisession.SDKFailWithAPIError(err, fmt.Sprintf("failed to get self tenant with error %v", err))
 	}
 	if resp == nil || resp.Payload == nil {
 		return nil, fmt.Errorf("failed to get self tenant")

--- a/clients/instance/ibm-pi-volume-group.go
+++ b/clients/instance/ibm-pi-volume-group.go
@@ -30,7 +30,7 @@ func (f *IBMPIVolumeGroupClient) Get(id string) (*models.VolumeGroup, error) {
 		WithCloudInstanceID(f.cloudInstanceID).WithVolumeGroupID(id)
 	resp, err := f.session.Power.PCloudVolumeGroups.PcloudVolumegroupsGet(params, f.session.AuthInfo(f.cloudInstanceID))
 	if err != nil {
-		return nil, fmt.Errorf(errors.GetVolumeGroupOperationFailed, id, f.cloudInstanceID, err)
+		return nil, ibmpisession.SDKFailWithAPIError(err, fmt.Sprintf(errors.GetVolumeGroupOperationFailed, id, f.cloudInstanceID, err))
 	}
 	if resp == nil || resp.Payload == nil {
 		return nil, fmt.Errorf("failed to get volume-group %s", id)
@@ -45,7 +45,7 @@ func (f *IBMPIVolumeGroupClient) GetAll() (*models.VolumeGroups, error) {
 		WithCloudInstanceID(f.cloudInstanceID)
 	resp, err := f.session.Power.PCloudVolumeGroups.PcloudVolumegroupsGetall(params, f.session.AuthInfo(f.cloudInstanceID))
 	if err != nil {
-		return nil, fmt.Errorf("failed to Get all volume-groups for Cloud Instance %s: %w", f.cloudInstanceID, err)
+		return nil, ibmpisession.SDKFailWithAPIError(err, fmt.Sprintf("failed to Get all volume-groups for Cloud Instance %s: %v", f.cloudInstanceID, err))
 	}
 	if resp == nil || resp.Payload == nil {
 		return nil, fmt.Errorf("failed to Get all volume-groups for Cloud Instance %s", f.cloudInstanceID)
@@ -60,7 +60,7 @@ func (f *IBMPIVolumeGroupClient) GetDetails(id string) (*models.VolumeGroupDetai
 		WithCloudInstanceID(f.cloudInstanceID).WithVolumeGroupID(id)
 	resp, err := f.session.Power.PCloudVolumeGroups.PcloudVolumegroupsGetDetails(params, f.session.AuthInfo(f.cloudInstanceID))
 	if err != nil {
-		return nil, fmt.Errorf(errors.GetVolumeGroupDetailsOperationFailed, id, f.cloudInstanceID, err)
+		return nil, ibmpisession.SDKFailWithAPIError(err, fmt.Sprintf(errors.GetVolumeGroupDetailsOperationFailed, id, f.cloudInstanceID, err))
 	}
 	if resp == nil || resp.Payload == nil {
 		return nil, fmt.Errorf("failed to get volume-group %s details", id)
@@ -75,7 +75,7 @@ func (f *IBMPIVolumeGroupClient) GetAllDetails() (*models.VolumeGroupsDetails, e
 		WithCloudInstanceID(f.cloudInstanceID)
 	resp, err := f.session.Power.PCloudVolumeGroups.PcloudVolumegroupsGetallDetails(params, f.session.AuthInfo(f.cloudInstanceID))
 	if err != nil {
-		return nil, fmt.Errorf("failed to Get all volume-groups details for Cloud Instance %s: %w", f.cloudInstanceID, err)
+		return nil, ibmpisession.SDKFailWithAPIError(err, fmt.Sprintf("failed to Get all volume-groups details for Cloud Instance %s: %v", f.cloudInstanceID, err))
 	}
 	if resp == nil || resp.Payload == nil {
 		return nil, fmt.Errorf("failed to Get all volume-groups details for Cloud Instance %s", f.cloudInstanceID)
@@ -90,7 +90,7 @@ func (f *IBMPIVolumeGroupClient) CreateVolumeGroup(body *models.VolumeGroupCreat
 		WithCloudInstanceID(f.cloudInstanceID).WithBody(body)
 	respOk, respPartial, err := f.session.Power.PCloudVolumeGroups.PcloudVolumegroupsPost(params, f.session.AuthInfo(f.cloudInstanceID))
 	if err != nil {
-		return nil, fmt.Errorf(errors.CreateVolumeGroupOperationFailed, f.cloudInstanceID, err)
+		return nil, ibmpisession.SDKFailWithAPIError(err, fmt.Sprintf(errors.CreateVolumeGroupOperationFailed, f.cloudInstanceID, err))
 	}
 	if respOk != nil && respOk.Payload != nil {
 		return respOk.Payload, nil
@@ -135,7 +135,7 @@ func (f *IBMPIVolumeGroupClient) GetVolumeGroupLiveDetails(id string) (*models.V
 		WithCloudInstanceID(f.cloudInstanceID).WithVolumeGroupID(id)
 	resp, err := f.session.Power.PCloudVolumeGroups.PcloudVolumegroupsStorageDetailsGet(params, f.session.AuthInfo(f.cloudInstanceID))
 	if err != nil {
-		return nil, fmt.Errorf(errors.GetLiveVolumeGroupDetailsOperationFailed, id, f.cloudInstanceID, err)
+		return nil, ibmpisession.SDKFailWithAPIError(err, fmt.Sprintf(errors.GetLiveVolumeGroupDetailsOperationFailed, id, f.cloudInstanceID, err))
 	}
 	if resp == nil || resp.Payload == nil {
 		return nil, fmt.Errorf("failed to get live details of volume-group %s", id)
@@ -150,7 +150,7 @@ func (f *IBMPIVolumeGroupClient) VolumeGroupAction(id string, body *models.Volum
 		WithCloudInstanceID(f.cloudInstanceID).WithVolumeGroupID(id).WithBody(body)
 	resp, err := f.session.Power.PCloudVolumeGroups.PcloudVolumegroupsActionPost(params, f.session.AuthInfo(f.cloudInstanceID))
 	if err != nil {
-		return nil, fmt.Errorf(errors.VolumeGroupActionOperationFailed, id, f.cloudInstanceID, err)
+		return nil, ibmpisession.SDKFailWithAPIError(err, fmt.Sprintf(errors.VolumeGroupActionOperationFailed, id, f.cloudInstanceID, err))
 	}
 	if resp == nil || resp.Payload == nil {
 		return nil, fmt.Errorf("failed to perform action on volume-group %s", id)
@@ -165,7 +165,7 @@ func (f *IBMPIVolumeGroupClient) GetVolumeGroupRemoteCopyRelationships(id string
 		WithCloudInstanceID(f.cloudInstanceID).WithVolumeGroupID(id)
 	resp, err := f.session.Power.PCloudVolumeGroups.PcloudVolumegroupsRemoteCopyRelationshipsGet(params, f.session.AuthInfo(f.cloudInstanceID))
 	if err != nil {
-		return nil, fmt.Errorf(errors.GetVolumeGroupRemoteCopyRelationshipsOperationFailed, id, f.cloudInstanceID, err)
+		return nil, ibmpisession.SDKFailWithAPIError(err, fmt.Sprintf(errors.GetVolumeGroupRemoteCopyRelationshipsOperationFailed, id, f.cloudInstanceID, err))
 	}
 	if resp == nil || resp.Payload == nil {
 		return nil, fmt.Errorf("failed to Get remote copy relationships of the volumes belonging to volume group %s", id)

--- a/clients/instance/ibm-pi-volume-onboarding.go
+++ b/clients/instance/ibm-pi-volume-onboarding.go
@@ -33,7 +33,7 @@ func (f *IBMPIVolumeOnboardingClient) Get(id string) (*models.VolumeOnboarding, 
 		WithCloudInstanceID(f.cloudInstanceID).WithVolumeOnboardingID(id)
 	resp, err := f.session.Power.PCloudVolumeOnboarding.PcloudVolumeOnboardingGet(params, f.session.AuthInfo(f.cloudInstanceID))
 	if err != nil {
-		return nil, fmt.Errorf(errors.GetVolumeOnboardingOperationFailed, id, f.cloudInstanceID, err)
+		return nil, ibmpisession.SDKFailWithAPIError(err, fmt.Sprintf(errors.GetVolumeOnboardingOperationFailed, id, f.cloudInstanceID, err))
 	}
 	if resp == nil || resp.Payload == nil {
 		return nil, fmt.Errorf("failed to Get Volume Onboarding for volume-onboarding ID:%s", id)
@@ -51,7 +51,7 @@ func (f *IBMPIVolumeOnboardingClient) GetAll() (*models.VolumeOnboardings, error
 		WithCloudInstanceID(f.cloudInstanceID)
 	resp, err := f.session.Power.PCloudVolumeOnboarding.PcloudVolumeOnboardingGetall(params, f.session.AuthInfo(f.cloudInstanceID))
 	if err != nil {
-		return nil, fmt.Errorf(errors.GetAllVolumeOnboardingsOperationFailed, f.cloudInstanceID, err)
+		return nil, ibmpisession.SDKFailWithAPIError(err, fmt.Sprintf(errors.GetAllVolumeOnboardingsOperationFailed, f.cloudInstanceID, err))
 	}
 	if resp == nil || resp.Payload == nil {
 		return nil, fmt.Errorf("failed to Get All Volume Onboardings for the cloud instance %s", f.cloudInstanceID)
@@ -69,7 +69,7 @@ func (f *IBMPIVolumeOnboardingClient) CreateVolumeOnboarding(body *models.Volume
 		WithCloudInstanceID(f.cloudInstanceID).WithBody(body)
 	resp, err := f.session.Power.PCloudVolumeOnboarding.PcloudVolumeOnboardingPost(params, f.session.AuthInfo(f.cloudInstanceID))
 	if err != nil {
-		return nil, fmt.Errorf(errors.CreateVolumeOnboardingsOperationFailed, f.cloudInstanceID, err)
+		return nil, ibmpisession.SDKFailWithAPIError(err, fmt.Sprintf(errors.CreateVolumeOnboardingsOperationFailed, f.cloudInstanceID, err))
 	}
 	if resp == nil || resp.Payload == nil {
 		return nil, fmt.Errorf("failed to Create Volume Onboarding")

--- a/clients/instance/ibm-pi-volume.go
+++ b/clients/instance/ibm-pi-volume.go
@@ -31,7 +31,7 @@ func (f *IBMPIVolumeClient) Get(id string) (*models.Volume, error) {
 		WithCloudInstanceID(f.cloudInstanceID).WithVolumeID(id)
 	resp, err := f.session.Power.PCloudVolumes.PcloudCloudinstancesVolumesGet(params, f.session.AuthInfo(f.cloudInstanceID))
 	if err != nil {
-		return nil, fmt.Errorf(errors.GetVolumeOperationFailed, id, err)
+		return nil, ibmpisession.SDKFailWithAPIError(err, fmt.Sprintf(errors.GetVolumeOperationFailed, id, err))
 	}
 	if resp == nil || resp.Payload == nil {
 		return nil, fmt.Errorf("failed to Get Volume %s", id)
@@ -46,7 +46,7 @@ func (f *IBMPIVolumeClient) GetAll() (*models.Volumes, error) {
 		WithCloudInstanceID(f.cloudInstanceID)
 	resp, err := f.session.Power.PCloudVolumes.PcloudCloudinstancesVolumesGetall(params, f.session.AuthInfo(f.cloudInstanceID))
 	if err != nil {
-		return nil, fmt.Errorf("failed to Get all Volumes for Cloud Instance %s: %w", f.cloudInstanceID, err)
+		return nil, ibmpisession.SDKFailWithAPIError(err, fmt.Sprintf("failed to Get all Volumes for Cloud Instance %s: %v", f.cloudInstanceID, err))
 	}
 	if resp == nil || resp.Payload == nil {
 		return nil, fmt.Errorf("failed to Get all Volumes for Cloud Instance %s", f.cloudInstanceID)
@@ -61,7 +61,7 @@ func (f *IBMPIVolumeClient) GetAllAffinityVolumes(affinity string) (*models.Volu
 		WithCloudInstanceID(f.cloudInstanceID).WithAffinity(&affinity)
 	resp, err := f.session.Power.PCloudVolumes.PcloudCloudinstancesVolumesGetall(params, f.session.AuthInfo(f.cloudInstanceID))
 	if err != nil {
-		return nil, fmt.Errorf("failed to Get all Volumes with affinity %s for Cloud Instance %s: %w", affinity, f.cloudInstanceID, err)
+		return nil, ibmpisession.SDKFailWithAPIError(err, fmt.Sprintf("failed to Get all Volumes with affinity %s for Cloud Instance %s: %v", affinity, f.cloudInstanceID, err))
 	}
 	if resp == nil || resp.Payload == nil {
 		return nil, fmt.Errorf("failed to Get all Volumes with affinity %s for Cloud Instance %s", affinity, f.cloudInstanceID)
@@ -76,7 +76,7 @@ func (f *IBMPIVolumeClient) CreateVolumeV2(body *models.MultiVolumesCreate) (*mo
 		WithCloudInstanceID(f.cloudInstanceID).WithBody(body)
 	resp, err := f.session.Power.PCloudVolumes.PcloudV2VolumesPost(params, f.session.AuthInfo(f.cloudInstanceID))
 	if err != nil {
-		return nil, fmt.Errorf(errors.CreateVolumeV2OperationFailed, *body.Name, err)
+		return nil, ibmpisession.SDKFailWithAPIError(err, fmt.Sprintf(errors.CreateVolumeV2OperationFailed, *body.Name, err))
 	}
 	if resp == nil || resp.Payload == nil {
 		return nil, fmt.Errorf("failed to Create Volume v2")
@@ -91,7 +91,7 @@ func (f *IBMPIVolumeClient) CreateVolume(body *models.CreateDataVolume) (*models
 		WithCloudInstanceID(f.cloudInstanceID).WithBody(body)
 	resp, err := f.session.Power.PCloudVolumes.PcloudCloudinstancesVolumesPost(params, f.session.AuthInfo(f.cloudInstanceID))
 	if err != nil {
-		return nil, fmt.Errorf(errors.CreateVolumeOperationFailed, *body.Name, err)
+		return nil, ibmpisession.SDKFailWithAPIError(err, fmt.Sprintf(errors.CreateVolumeOperationFailed, *body.Name, err))
 	}
 	if resp == nil || resp.Payload == nil {
 		return nil, fmt.Errorf("failed to Create Volume")
@@ -107,7 +107,7 @@ func (f *IBMPIVolumeClient) UpdateVolume(id string, body *models.UpdateVolume) (
 		WithBody(body)
 	resp, err := f.session.Power.PCloudVolumes.PcloudCloudinstancesVolumesPut(params, f.session.AuthInfo(f.cloudInstanceID))
 	if err != nil {
-		return nil, fmt.Errorf(errors.UpdateVolumeOperationFailed, id, err)
+		return nil, ibmpisession.SDKFailWithAPIError(err, fmt.Sprintf(errors.UpdateVolumeOperationFailed, id, err))
 	}
 	if resp == nil || resp.Payload == nil {
 		return nil, fmt.Errorf("failed to Update Volume %s", id)
@@ -160,7 +160,7 @@ func (f *IBMPIVolumeClient) GetAllInstanceVolumes(id string) (*models.Volumes, e
 		WithCloudInstanceID(f.cloudInstanceID).WithPvmInstanceID(id)
 	resp, err := f.session.Power.PCloudVolumes.PcloudPvminstancesVolumesGetall(params, f.session.AuthInfo(f.cloudInstanceID))
 	if err != nil {
-		return nil, fmt.Errorf("failed to Get all Volumes for PI Instance %s: %w", id, err)
+		return nil, ibmpisession.SDKFailWithAPIError(err, fmt.Sprintf("failed to Get all Volumes for PI Instance %s: %v", id, err))
 	}
 	if resp == nil || resp.Payload == nil {
 		return nil, fmt.Errorf("failed to Get all Volumes for PI Instance %s", id)
@@ -189,7 +189,7 @@ func (f *IBMPIVolumeClient) CheckVolumeAttach(id, volumeID string) (*models.Volu
 		WithVolumeID(volumeID)
 	resp, err := f.session.Power.PCloudVolumes.PcloudPvminstancesVolumesGet(params, f.session.AuthInfo(f.cloudInstanceID))
 	if err != nil {
-		return nil, fmt.Errorf("failed to validate that the volume %s is attached to the pvminstance %s: %w", volumeID, id, err)
+		return nil, ibmpisession.SDKFailWithAPIError(err, fmt.Sprintf("failed to validate that the volume %s is attached to the pvminstance %s: %v", volumeID, id, err))
 	}
 	if resp == nil || resp.Payload == nil {
 		return nil, fmt.Errorf("failed to validate that the volume %s is attached to the pvminstance %s", volumeID, id)
@@ -205,7 +205,7 @@ func (f *IBMPIVolumeClient) UpdateVolumeAttach(id, volumeID string, body *models
 		WithVolumeID(volumeID).WithBody(body)
 	resp, err := f.session.Power.PCloudVolumes.PcloudPvminstancesVolumesPut(params, f.session.AuthInfo(f.cloudInstanceID))
 	if err != nil {
-		return fmt.Errorf("failed to validate that the volume %s is attached to the pvminstance %s: %w", volumeID, id, err)
+		return fmt.Errorf("failed to validate that the volume %s is attached to the pvminstance %s: %v", volumeID, id, err)
 	}
 	if resp == nil || resp.Payload == nil {
 		return fmt.Errorf("failed to validate that the volume %s is attached to the pvminstance %s", volumeID, id)
@@ -220,7 +220,7 @@ func (f *IBMPIVolumeClient) VolumeAction(id string, body *models.VolumeAction) e
 		WithCloudInstanceID(f.cloudInstanceID).WithVolumeID(id).WithBody(body)
 	_, err := f.session.Power.PCloudVolumes.PcloudCloudinstancesVolumesActionPost(params, f.session.AuthInfo(f.cloudInstanceID))
 	if err != nil {
-		return fmt.Errorf("failed to perform action on volume %s with error %w", id, err)
+		return fmt.Errorf("failed to perform action on volume %s with error %v", id, err)
 	}
 	return nil
 }
@@ -232,7 +232,7 @@ func (f *IBMPIVolumeClient) GetVolumeRemoteCopyRelationships(id string) (*models
 		WithCloudInstanceID(f.cloudInstanceID).WithVolumeID(id)
 	resp, err := f.session.Power.PCloudVolumes.PcloudCloudinstancesVolumesRemoteCopyRelationshipGet(params, f.session.AuthInfo(f.cloudInstanceID))
 	if err != nil {
-		return nil, fmt.Errorf(errors.GetVolumeRemoteCopyRelationshipsOperationFailed, id, f.cloudInstanceID, err)
+		return nil, ibmpisession.SDKFailWithAPIError(err, fmt.Sprintf(errors.GetVolumeRemoteCopyRelationshipsOperationFailed, id, f.cloudInstanceID, err))
 	}
 	if resp == nil || resp.Payload == nil {
 		return nil, fmt.Errorf("failed to Get remote copy relationships of a volume %s", id)
@@ -247,7 +247,7 @@ func (f *IBMPIVolumeClient) GetVolumeFlashCopyMappings(id string) (models.FlashC
 		WithCloudInstanceID(f.cloudInstanceID).WithVolumeID(id)
 	resp, err := f.session.Power.PCloudVolumes.PcloudCloudinstancesVolumesFlashCopyMappingsGet(params, f.session.AuthInfo(f.cloudInstanceID))
 	if err != nil {
-		return nil, fmt.Errorf(errors.GetVolumeFlashCopyMappingOperationFailed, id, f.cloudInstanceID, err)
+		return nil, ibmpisession.SDKFailWithAPIError(err, fmt.Sprintf(errors.GetVolumeFlashCopyMappingOperationFailed, id, f.cloudInstanceID, err))
 	}
 	if resp == nil || resp.Payload == nil {
 		return nil, fmt.Errorf("failed to Get flash copy mapping of a volume %s", id)

--- a/clients/instance/ibm-pi-vpn-policy.go
+++ b/clients/instance/ibm-pi-vpn-policy.go
@@ -35,7 +35,7 @@ func (f *IBMPIVpnPolicyClient) GetIKEPolicy(id string) (*models.IKEPolicy, error
 		WithCloudInstanceID(f.cloudInstanceID).WithIkePolicyID(id)
 	resp, err := f.session.Power.PCloudvpnPolicies.PcloudIkepoliciesGet(params, f.session.AuthInfo(f.cloudInstanceID))
 	if err != nil {
-		return nil, fmt.Errorf(errors.GetVPNPolicyOperationFailed, id, err)
+		return nil, ibmpisession.SDKFailWithAPIError(err, fmt.Sprintf(errors.GetVPNPolicyOperationFailed, id, err))
 	}
 	if resp == nil || resp.Payload == nil {
 		return nil, fmt.Errorf("failed to get ike policy for policy id %s", id)
@@ -53,7 +53,7 @@ func (f *IBMPIVpnPolicyClient) CreateIKEPolicy(body *models.IKEPolicyCreate) (*m
 		WithCloudInstanceID(f.cloudInstanceID).WithBody(body)
 	postok, err := f.session.Power.PCloudvpnPolicies.PcloudIkepoliciesPost(params, f.session.AuthInfo(f.cloudInstanceID))
 	if err != nil {
-		return nil, fmt.Errorf(errors.CreateVPNPolicyOperationFailed, f.cloudInstanceID, err)
+		return nil, ibmpisession.SDKFailWithAPIError(err, fmt.Sprintf(errors.CreateVPNPolicyOperationFailed, f.cloudInstanceID, err))
 	}
 	if postok != nil && postok.Payload != nil {
 		return postok.Payload, nil
@@ -72,7 +72,7 @@ func (f *IBMPIVpnPolicyClient) UpdateIKEPolicy(id string, body *models.IKEPolicy
 		WithBody(body)
 	putok, err := f.session.Power.PCloudvpnPolicies.PcloudIkepoliciesPut(params, f.session.AuthInfo(f.cloudInstanceID))
 	if err != nil {
-		return nil, fmt.Errorf(errors.UpdateVPNPolicyOperationFailed, id, err)
+		return nil, ibmpisession.SDKFailWithAPIError(err, fmt.Sprintf(errors.UpdateVPNPolicyOperationFailed, id, err))
 	}
 	if putok != nil && putok.Payload != nil {
 		return putok.Payload, nil
@@ -90,7 +90,7 @@ func (f *IBMPIVpnPolicyClient) GetAllIKEPolicies() (*models.IKEPolicies, error) 
 		WithCloudInstanceID(f.cloudInstanceID)
 	resp, err := f.session.Power.PCloudvpnPolicies.PcloudIkepoliciesGetall(params, f.session.AuthInfo(f.cloudInstanceID))
 	if err != nil {
-		return nil, fmt.Errorf("failed to get all ike policies: %w", err)
+		return nil, ibmpisession.SDKFailWithAPIError(err, fmt.Sprintf("failed to get all ike policies: %v", err))
 	}
 	if resp == nil || resp.Payload == nil {
 		return nil, fmt.Errorf("failed to get all ike policies")
@@ -124,7 +124,7 @@ func (f *IBMPIVpnPolicyClient) GetIPSecPolicy(id string) (*models.IPSecPolicy, e
 		WithCloudInstanceID(f.cloudInstanceID).WithIpsecPolicyID(id)
 	resp, err := f.session.Power.PCloudvpnPolicies.PcloudIpsecpoliciesGet(params, f.session.AuthInfo(f.cloudInstanceID))
 	if err != nil {
-		return nil, fmt.Errorf(errors.GetVPNPolicyOperationFailed, id, err)
+		return nil, ibmpisession.SDKFailWithAPIError(err, fmt.Sprintf(errors.GetVPNPolicyOperationFailed, id, err))
 	}
 	if resp == nil || resp.Payload == nil {
 		return nil, fmt.Errorf("failed to get ipsec policy for policy id %s", id)
@@ -142,7 +142,7 @@ func (f *IBMPIVpnPolicyClient) CreateIPSecPolicy(body *models.IPSecPolicyCreate)
 		WithCloudInstanceID(f.cloudInstanceID).WithBody(body)
 	postok, err := f.session.Power.PCloudvpnPolicies.PcloudIpsecpoliciesPost(params, f.session.AuthInfo(f.cloudInstanceID))
 	if err != nil {
-		return nil, fmt.Errorf(errors.CreateVPNPolicyOperationFailed, f.cloudInstanceID, err)
+		return nil, ibmpisession.SDKFailWithAPIError(err, fmt.Sprintf(errors.CreateVPNPolicyOperationFailed, f.cloudInstanceID, err))
 	}
 	if postok != nil && postok.Payload != nil {
 		return postok.Payload, nil
@@ -161,7 +161,7 @@ func (f *IBMPIVpnPolicyClient) UpdateIPSecPolicy(id string, body *models.IPSecPo
 		WithBody(body)
 	putok, err := f.session.Power.PCloudvpnPolicies.PcloudIpsecpoliciesPut(params, f.session.AuthInfo(f.cloudInstanceID))
 	if err != nil {
-		return nil, fmt.Errorf(errors.UpdateVPNPolicyOperationFailed, id, err)
+		return nil, ibmpisession.SDKFailWithAPIError(err, fmt.Sprintf(errors.UpdateVPNPolicyOperationFailed, id, err))
 	}
 	if putok != nil && putok.Payload != nil {
 		return putok.Payload, nil
@@ -179,7 +179,7 @@ func (f *IBMPIVpnPolicyClient) GetAllIPSecPolicies() (*models.IPSecPolicies, err
 		WithCloudInstanceID(f.cloudInstanceID)
 	resp, err := f.session.Power.PCloudvpnPolicies.PcloudIpsecpoliciesGetall(params, f.session.AuthInfo(f.cloudInstanceID))
 	if err != nil {
-		return nil, fmt.Errorf("failed to get all ipsec policies: %w", err)
+		return nil, ibmpisession.SDKFailWithAPIError(err, fmt.Sprintf("failed to get all ipsec policies: %v", err))
 	}
 	if resp == nil || resp.Payload == nil {
 		return nil, fmt.Errorf("failed to get all ipsec policies")

--- a/clients/instance/ibm-pi-vpn.go
+++ b/clients/instance/ibm-pi-vpn.go
@@ -34,7 +34,7 @@ func (f *IBMPIVpnConnectionClient) Get(id string) (*models.VPNConnection, error)
 		WithCloudInstanceID(f.cloudInstanceID).WithVpnConnectionID(id)
 	resp, err := f.session.Power.PCloudvpnConnections.PcloudVpnconnectionsGet(params, f.session.AuthInfo(f.cloudInstanceID))
 	if err != nil {
-		return nil, fmt.Errorf(errors.GetVPNConnectionOperationFailed, id, err)
+		return nil, ibmpisession.SDKFailWithAPIError(err, fmt.Sprintf(errors.GetVPNConnectionOperationFailed, id, err))
 	}
 	if resp == nil || resp.Payload == nil {
 		return nil, fmt.Errorf("failed to Get VPN Connection %s", id)
@@ -52,7 +52,7 @@ func (f *IBMPIVpnConnectionClient) Create(body *models.VPNConnectionCreate) (*mo
 		WithCloudInstanceID(f.cloudInstanceID).WithBody(body)
 	postaccepted, err := f.session.Power.PCloudvpnConnections.PcloudVpnconnectionsPost(params, f.session.AuthInfo(f.cloudInstanceID))
 	if err != nil {
-		return nil, fmt.Errorf(errors.CreateVPNConnectionOperationFailed, f.cloudInstanceID, err)
+		return nil, ibmpisession.SDKFailWithAPIError(err, fmt.Sprintf(errors.CreateVPNConnectionOperationFailed, f.cloudInstanceID, err))
 	}
 	if postaccepted != nil && postaccepted.Payload != nil {
 		return postaccepted.Payload, nil
@@ -71,7 +71,7 @@ func (f *IBMPIVpnConnectionClient) Update(id string, body *models.VPNConnectionU
 		WithBody(body)
 	putok, err := f.session.Power.PCloudvpnConnections.PcloudVpnconnectionsPut(params, f.session.AuthInfo(f.cloudInstanceID))
 	if err != nil {
-		return nil, fmt.Errorf(errors.UpdateVPNConnectionOperationFailed, id, err)
+		return nil, ibmpisession.SDKFailWithAPIError(err, fmt.Sprintf(errors.UpdateVPNConnectionOperationFailed, id, err))
 	}
 	if putok != nil && putok.Payload != nil {
 		return putok.Payload, nil
@@ -89,7 +89,7 @@ func (f *IBMPIVpnConnectionClient) GetAll() (*models.VPNConnections, error) {
 		WithCloudInstanceID(f.cloudInstanceID)
 	resp, err := f.session.Power.PCloudvpnConnections.PcloudVpnconnectionsGetall(params, f.session.AuthInfo(f.cloudInstanceID))
 	if err != nil {
-		return nil, fmt.Errorf("failed to Get all VPN Connections: %w", err)
+		return nil, ibmpisession.SDKFailWithAPIError(err, fmt.Sprintf("failed to Get all VPN Connections: %v", err))
 	}
 	if resp == nil || resp.Payload == nil {
 		return nil, fmt.Errorf("failed to Get all VPN Connections")
@@ -107,7 +107,7 @@ func (f *IBMPIVpnConnectionClient) Delete(id string) (*models.JobReference, erro
 		WithCloudInstanceID(f.cloudInstanceID).WithVpnConnectionID(id)
 	delaccepted, err := f.session.Power.PCloudvpnConnections.PcloudVpnconnectionsDelete(params, f.session.AuthInfo(f.cloudInstanceID))
 	if err != nil {
-		return nil, fmt.Errorf(errors.DeleteVPNConnectionOperationFailed, id, err)
+		return nil, ibmpisession.SDKFailWithAPIError(err, fmt.Sprintf(errors.DeleteVPNConnectionOperationFailed, id, err))
 	}
 	if delaccepted != nil && delaccepted.Payload != nil {
 		return delaccepted.Payload, nil
@@ -125,7 +125,7 @@ func (f *IBMPIVpnConnectionClient) GetNetwork(id string) (*models.NetworkIDs, er
 		WithCloudInstanceID(f.cloudInstanceID).WithVpnConnectionID(id)
 	resp, err := f.session.Power.PCloudvpnConnections.PcloudVpnconnectionsNetworksGet(params, f.session.AuthInfo(f.cloudInstanceID))
 	if err != nil {
-		return nil, fmt.Errorf("failed to Get Networks for VPN Connection %s: %w", id, err)
+		return nil, ibmpisession.SDKFailWithAPIError(err, fmt.Sprintf("failed to Get Networks for VPN Connection %s: %v", id, err))
 	}
 	if resp == nil || resp.Payload == nil {
 		return nil, fmt.Errorf("failed to Get Networks for VPN Connection %s", id)
@@ -144,7 +144,7 @@ func (f *IBMPIVpnConnectionClient) AddNetwork(id, networkID string) (*models.Job
 		WithBody(&models.NetworkID{NetworkID: &networkID})
 	resp, err := f.session.Power.PCloudvpnConnections.PcloudVpnconnectionsNetworksPut(params, f.session.AuthInfo(f.cloudInstanceID))
 	if err != nil {
-		return nil, fmt.Errorf("failed to Add Network %s to VPN Connection %s: %w", networkID, id, err)
+		return nil, ibmpisession.SDKFailWithAPIError(err, fmt.Sprintf("failed to Add Network %s to VPN Connection %s: %v", networkID, id, err))
 	}
 	if resp != nil && resp.Payload != nil {
 		return resp.Payload, nil
@@ -163,7 +163,7 @@ func (f *IBMPIVpnConnectionClient) DeleteNetwork(id, networkID string) (*models.
 		WithBody(&models.NetworkID{NetworkID: &networkID})
 	resp, err := f.session.Power.PCloudvpnConnections.PcloudVpnconnectionsNetworksDelete(params, f.session.AuthInfo(f.cloudInstanceID))
 	if err != nil {
-		return nil, fmt.Errorf("failed to Delete Network %s from VPN Connection %s: %w", networkID, id, err)
+		return nil, ibmpisession.SDKFailWithAPIError(err, fmt.Sprintf("failed to Delete Network %s from VPN Connection %s: %v", networkID, id, err))
 	}
 	if resp != nil && resp.Payload != nil {
 		return resp.Payload, nil
@@ -181,7 +181,7 @@ func (f *IBMPIVpnConnectionClient) GetSubnet(id string) (*models.PeerSubnets, er
 		WithCloudInstanceID(f.cloudInstanceID).WithVpnConnectionID(id)
 	resp, err := f.session.Power.PCloudvpnConnections.PcloudVpnconnectionsPeersubnetsGet(params, f.session.AuthInfo(f.cloudInstanceID))
 	if err != nil {
-		return nil, fmt.Errorf("failed to Get Subnets from VPN Connection %s: %w", id, err)
+		return nil, ibmpisession.SDKFailWithAPIError(err, fmt.Sprintf("failed to Get Subnets from VPN Connection %s: %v", id, err))
 	}
 	if resp == nil || resp.Payload == nil {
 		return nil, fmt.Errorf("failed to Get Subnets from VPN Connection %s", id)
@@ -200,7 +200,7 @@ func (f *IBMPIVpnConnectionClient) AddSubnet(id, subnet string) (*models.PeerSub
 		WithBody(&models.PeerSubnetUpdate{Cidr: &subnet})
 	resp, err := f.session.Power.PCloudvpnConnections.PcloudVpnconnectionsPeersubnetsPut(params, f.session.AuthInfo(f.cloudInstanceID))
 	if err != nil {
-		return nil, fmt.Errorf("failed to Add Subnets to VPN Connection %s: %w", id, err)
+		return nil, ibmpisession.SDKFailWithAPIError(err, fmt.Sprintf("failed to Add Subnets to VPN Connection %s: %v", id, err))
 	}
 	if resp == nil || resp.Payload == nil {
 		return nil, fmt.Errorf("failed to Add Subnets to VPN Connection %s", id)
@@ -219,7 +219,7 @@ func (f *IBMPIVpnConnectionClient) DeleteSubnet(id, subnet string) (*models.Peer
 		WithBody(&models.PeerSubnetUpdate{Cidr: &subnet})
 	resp, err := f.session.Power.PCloudvpnConnections.PcloudVpnconnectionsPeersubnetsDelete(params, f.session.AuthInfo(f.cloudInstanceID))
 	if err != nil {
-		return nil, fmt.Errorf("failed to Delete Subnet from VPN Connection %s: %w", id, err)
+		return nil, ibmpisession.SDKFailWithAPIError(err, fmt.Sprintf("failed to Delete Subnet from VPN Connection %s: %v", id, err))
 	}
 	if resp == nil || resp.Payload == nil {
 		return nil, fmt.Errorf("failed to Delete Subnet from VPN Connection %s", id)

--- a/errors/errors.go
+++ b/errors/errors.go
@@ -10,114 +10,114 @@ import (
 
 // start of Placementgroup Messages
 
-const GetPlacementGroupOperationFailed = "failed to perform Get Placement Group Operation for placement group %s with error %w"
-const CreatePlacementGroupOperationFailed = "failed to perform Create Placement Group Operation for cloud instance %s with error  %w"
-const DeletePlacementGroupOperationFailed = "failed to perform Delete Placement Group Operation for placement group %s with error %w"
-const AddMemberPlacementGroupOperationFailed = "failed to perform Add Member Operation for instance %s and placement group %s with error %w"
-const DeleteMemberPlacementGroupOperationFailed = "failed to perform Delete Member Operation for instance %s and placement group %s with error %w"
+const GetPlacementGroupOperationFailed = "failed to perform Get Placement Group Operation for placement group %s with error %v"
+const CreatePlacementGroupOperationFailed = "failed to perform Create Placement Group Operation for cloud instance %s with error  %v"
+const DeletePlacementGroupOperationFailed = "failed to perform Delete Placement Group Operation for placement group %s with error %v"
+const AddMemberPlacementGroupOperationFailed = "failed to perform Add Member Operation for instance %s and placement group %s with error %v"
+const DeleteMemberPlacementGroupOperationFailed = "failed to perform Delete Member Operation for instance %s and placement group %s with error %v"
 
 // start of Cloud Connection Messages
 
-const GetCloudConnectionOperationFailed = "failed to perform Get Cloud Connections Operation for cloudconnectionid %s with error %w"
-const CreateCloudConnectionOperationFailed = "failed to perform Create Cloud Connection Operation for cloud instance %s with error %w"
-const UpdateCloudConnectionOperationFailed = "failed to perform Update Cloud Connection Operation for cloudconnectionid %s with error %w"
-const DeleteCloudConnectionOperationFailed = "failed to perform Delete Cloud Connection Operation for cloudconnectionid %s with error %w"
+const GetCloudConnectionOperationFailed = "failed to perform Get Cloud Connections Operation for cloudconnectionid %s with error %v"
+const CreateCloudConnectionOperationFailed = "failed to perform Create Cloud Connection Operation for cloud instance %s with error %v"
+const UpdateCloudConnectionOperationFailed = "failed to perform Update Cloud Connection Operation for cloudconnectionid %s with error %v"
+const DeleteCloudConnectionOperationFailed = "failed to perform Delete Cloud Connection Operation for cloudconnectionid %s with error %v"
 
 // start of VPN Connection Messages
 
-const GetVPNConnectionOperationFailed = "failed to perform Get VPN Connection Operation for id %s with error %w"
-const CreateVPNConnectionOperationFailed = "failed to perform Create VPN Connection Operation for cloud instance %s with error %w"
-const UpdateVPNConnectionOperationFailed = "failed to perform Update VPN Connection Operation for id  %s with error %w"
-const DeleteVPNConnectionOperationFailed = "failed to perform Delete VPN Connection Operation for id  %s with error %w"
+const GetVPNConnectionOperationFailed = "failed to perform Get VPN Connection Operation for id %s with error %v"
+const CreateVPNConnectionOperationFailed = "failed to perform Create VPN Connection Operation for cloud instance %s with error %v"
+const UpdateVPNConnectionOperationFailed = "failed to perform Update VPN Connection Operation for id %s with error %v"
+const DeleteVPNConnectionOperationFailed = "failed to perform Delete VPN Connection Operation for id %s with error %v"
 
 // start of VPN Policy Messages
 
-const GetVPNPolicyOperationFailed = "failed to perform Get VPN Policy Operation for Policy id %s with error %w"
-const CreateVPNPolicyOperationFailed = "failed to perform Create VPN Policy Operation for cloud instance %s with error %w"
-const UpdateVPNPolicyOperationFailed = "failed to perform Update VPN Policy Operation for Policy id  %s with error %w"
-const DeleteVPNPolicyOperationFailed = "failed to perform Delete VPN Policy Operation for Policy id  %s with error %w"
+const GetVPNPolicyOperationFailed = "failed to perform Get VPN Policy Operation for Policy id %s with error %v"
+const CreateVPNPolicyOperationFailed = "failed to perform Create VPN Policy Operation for cloud instance %s with error %v"
+const UpdateVPNPolicyOperationFailed = "failed to perform Update VPN Policy Operation for Policy id %s with error %v"
+const DeleteVPNPolicyOperationFailed = "failed to perform Delete VPN Policy Operation for Policy id %s with error %v"
 
 // start of Job Messages
-const GetJobOperationFailed = "failed to perform get Job operation for job id %s with error %w"
-const GetAllJobsOperationFailed = "failed to perform get all jobs operation with error %w"
-const DeleteJobsOperationFailed = "failed to perform delete Job operation for job id %s with error %w"
+const GetJobOperationFailed = "failed to perform get Job operation for job id %s with error %v"
+const GetAllJobsOperationFailed = "failed to perform get all jobs operation with error %v"
+const DeleteJobsOperationFailed = "failed to perform delete Job operation for job id %s with error %v"
 
 // start of DHCP Messages
-const GetDhcpOperationFailed = "failed to perform Get DHCP Operation for dhcp id %s with error %w"
-const CreateDchpOperationFailed = "failed to perform Create DHCP Operation for cloud instance %s with error %w"
-const DeleteDhcpOperationFailed = "failed to perform Delete DHCP Operation for dhcp id %s with error %w"
+const GetDhcpOperationFailed = "failed to perform Get DHCP Operation for dhcp id %s with error %v"
+const CreateDchpOperationFailed = "failed to perform Create DHCP Operation for cloud instance %s with error %v"
+const DeleteDhcpOperationFailed = "failed to perform Delete DHCP Operation for dhcp id %s with error %v"
 
 // start of System-Pools Messages
-const GetSystemPoolsOperationFailed = "failed to perform Get System Pools Operation for cloud instance %s with error %w"
+const GetSystemPoolsOperationFailed = "failed to perform Get System Pools Operation for cloud instance %s with error %v"
 
 // start of Image Messages
 
-const GetImageOperationFailed = "failed to perform Get Image Operation for image %s with error %w"
-const CreateImageOperationFailed = "failed to perform Create Image Operation for cloud instance %s with error  %w"
+const GetImageOperationFailed = "failed to perform Get Image Operation for image %s with error %v"
+const CreateImageOperationFailed = "failed to perform Create Image Operation for cloud instance %s with error  %v"
 
 // Start of Network Messages
-const GetNetworkOperationFailed = "failed to perform Get Network Operation for Network id %s with error %w"
-const CreateNetworkOperationFailed = "failed to perform Create Network Operation for Network %s with error %w"
-const CreateNetworkPortOperationFailed = "failed to perform Create Network Port Operation for Network %s with error %w"
+const GetNetworkOperationFailed = "failed to perform Get Network Operation for Network id %s with error %v"
+const CreateNetworkOperationFailed = "failed to perform Create Network Operation for Network %s with error %v"
+const CreateNetworkPortOperationFailed = "failed to perform Create Network Port Operation for Network %s with error %v"
 
 // start of Volume Messages
-const DeleteVolumeOperationFailed = "failed to perform Delete Volume Operation for volume %s with error %w"
-const UpdateVolumeOperationFailed = "failed to perform Update Volume Operation for volume %s with error %w"
-const GetVolumeOperationFailed = "failed to perform the Get Volume Operation for volume %s with error %w"
-const CreateVolumeOperationFailed = "failed to perform the Create volume Operation for volume %s with error %w"
-const CreateVolumeV2OperationFailed = "failed to perform the Create volume Operation V2 for volume %s with error %w"
-const AttachVolumeOperationFailed = "failed to perform the Attach volume Operation for volume %s with error %w"
-const DetachVolumeOperationFailed = "failed to perform the Detach volume Operation for volume %s with error %w"
-const GetVolumeRemoteCopyRelationshipsOperationFailed = "failed to Get remote copy relationships of a volume %s for the cloud instance %s with error %w"
-const GetVolumeFlashCopyMappingOperationFailed = "failed to Get flash copy mapping of a volume %s for the cloud instance %s with error %w"
+const DeleteVolumeOperationFailed = "failed to perform Delete Volume Operation for volume %s with error %v"
+const UpdateVolumeOperationFailed = "failed to perform Update Volume Operation for volume %s with error %v"
+const GetVolumeOperationFailed = "failed to perform the Get Volume Operation for volume %s with error %v"
+const CreateVolumeOperationFailed = "failed to perform the Create volume Operation for volume %s with error %v"
+const CreateVolumeV2OperationFailed = "failed to perform the Create volume Operation V2 for volume %s with error %v"
+const AttachVolumeOperationFailed = "failed to perform the Attach volume Operation for volume %s with error %v"
+const DetachVolumeOperationFailed = "failed to perform the Detach volume Operation for volume %s with error %v"
+const GetVolumeRemoteCopyRelationshipsOperationFailed = "failed to Get remote copy relationships of a volume %s for the cloud instance %s with error %v"
+const GetVolumeFlashCopyMappingOperationFailed = "failed to Get flash copy mapping of a volume %s for the cloud instance %s with error %v"
 
 // start of volume onboarding
-const GetVolumeOnboardingOperationFailed = "failed to perform the Get Volume Onboarding Operation for volume-onboarding ID:%s for the cloud instance %s with error %w"
-const GetAllVolumeOnboardingsOperationFailed = "failed to perform the Get All Volume Onboardings Operation for the cloud instance %s with error %w"
-const CreateVolumeOnboardingsOperationFailed = "failed to perform the Create Volume Onboarding Operation for the cloud instance %s with error %w"
+const GetVolumeOnboardingOperationFailed = "failed to perform the Get Volume Onboarding Operation for volume-onboarding ID:%s for the cloud instance %s with error %v"
+const GetAllVolumeOnboardingsOperationFailed = "failed to perform the Get All Volume Onboardings Operation for the cloud instance %s with error %v"
+const CreateVolumeOnboardingsOperationFailed = "failed to perform the Create Volume Onboarding Operation for the cloud instance %s with error %v"
 
 // start of disaster recovery
-const GetDisasterRecoveryLocationOperationFailed = "failed to perform the Get Disaster Recovery Location Operation for the cloud instance %s with error %w"
-const GetAllDisasterRecoveryLocationOperationFailed = "failed to perform the Get All Disaster Recovery Location Operation of power virtual server with error %w"
+const GetDisasterRecoveryLocationOperationFailed = "failed to perform the Get Disaster Recovery Location Operation for the cloud instance %s with error %v"
+const GetAllDisasterRecoveryLocationOperationFailed = "failed to perform the Get All Disaster Recovery Location Operation of power virtual server with error %v"
 
 // start of Clone Messages
-const StartCloneOperationFailed = "failed to start the clone operation for volumes-clone %s with error %w"
-const PrepareCloneOperationFailed = "failed to prepare the clone operation for volumes-clone %s with error %w"
-const DeleteCloneOperationFailed = "failed to perform delete clone operation %w"
-const GetCloneOperationFailed = "failed to get the volumes-clone %s for the cloud instance %s with error %w"
-const CreateCloneOperationFailed = "failed to perform the create clone operation %w"
+const StartCloneOperationFailed = "failed to start the clone operation for volumes-clone %s with error %v"
+const PrepareCloneOperationFailed = "failed to prepare the clone operation for volumes-clone %s with error %v"
+const DeleteCloneOperationFailed = "failed to perform delete clone operation %v"
+const GetCloneOperationFailed = "failed to get the volumes-clone %s for the cloud instance %s with error %v"
+const CreateCloneOperationFailed = "failed to perform the create clone operation %v"
 
 // start of Cloud Instance Messages
-const GetCloudInstanceOperationFailed = "failed to Get Cloud Instance %s with error %w"
-const UpdateCloudInstanceOperationFailed = "failed to update the Cloud instance %s with error %w"
-const DeleteCloudInstanceOperationFailed = "failed to delete the Cloud instance %s with error %w"
+const GetCloudInstanceOperationFailed = "failed to Get Cloud Instance %s with error %v"
+const UpdateCloudInstanceOperationFailed = "failed to update the Cloud instance %s with error %v"
+const DeleteCloudInstanceOperationFailed = "failed to delete the Cloud instance %s with error %v"
 
 // start of PI Key Messages
-const GetPIKeyOperationFailed = "failed to Get PI Key %s with error %w"
-const CreatePIKeyOperationFailed = "failed to Create PI Key with error %w"
-const DeletePIKeyOperationFailed = "failed to Delete PI Key %s with error %w"
+const GetPIKeyOperationFailed = "failed to Get PI Key %s with error %v"
+const CreatePIKeyOperationFailed = "failed to Create PI Key with error %v"
+const DeletePIKeyOperationFailed = "failed to Delete PI Key %s with error %v"
 
 // start of Volume Groups
-const GetVolumeGroupOperationFailed = "failed to Get volume-group %s for the cloud instance %s with error %w"
-const GetVolumeGroupDetailsOperationFailed = "failed to Get volume-group %s details for the cloud instance %s with error %w"
-const CreateVolumeGroupOperationFailed = "failed to perform the Create volume-group Operation for the cloud instance %s with error %w"
-const DeleteVolumeGroupOperationFailed = "failed to perform Delete volume-group Operation for volume-group %s with error %w"
-const GetLiveVolumeGroupDetailsOperationFailed = "failed to Get live details of volume-group %s for the cloud instance %s with error %w"
-const VolumeGroupActionOperationFailed = "failed to perform action on volume-group %s for the cloud instance %s with error %w"
-const GetVolumeGroupRemoteCopyRelationshipsOperationFailed = "failed to Get remote copy relationships of the volumes belonging to volume group %s for the cloud instance %s with error %w"
+const GetVolumeGroupOperationFailed = "failed to Get volume-group %s for the cloud instance %s with error %v"
+const GetVolumeGroupDetailsOperationFailed = "failed to Get volume-group %s details for the cloud instance %s with error %v"
+const CreateVolumeGroupOperationFailed = "failed to perform the Create volume-group Operation for the cloud instance %s with error %v"
+const DeleteVolumeGroupOperationFailed = "failed to perform Delete volume-group Operation for volume-group %s with error %v"
+const GetLiveVolumeGroupDetailsOperationFailed = "failed to Get live details of volume-group %s for the cloud instance %s with error %v"
+const VolumeGroupActionOperationFailed = "failed to perform action on volume-group %s for the cloud instance %s with error %v"
+const GetVolumeGroupRemoteCopyRelationshipsOperationFailed = "failed to Get remote copy relationships of the volumes belonging to volume group %s for the cloud instance %s with error %v"
 
 // start of Shared processor pool Messages
-const GetSharedProcessorPoolOperationFailed = "failed to perform Get Shared Processor Pool Operation for pool %s with error %w"
-const CreateSharedProcessorPoolOperationFailed = "failed to perform Create Shared Processor Pool Operation for cloud instance %s with error  %w"
-const DeleteSharedProcessorPoolOperationFailed = "failed to perform Delete Shared Processor Pool Operation for pool %s with error %w"
-const UpdateSharedProcessorPoolOperationFailed = "failed to perform Update Shared Processor Pool Operation for pool %s with error %w"
+const GetSharedProcessorPoolOperationFailed = "failed to perform Get Shared Processor Pool Operation for pool %s with error %v"
+const CreateSharedProcessorPoolOperationFailed = "failed to perform Create Shared Processor Pool Operation for cloud instance %s with error  %v"
+const DeleteSharedProcessorPoolOperationFailed = "failed to perform Delete Shared Processor Pool Operation for pool %s with error %v"
+const UpdateSharedProcessorPoolOperationFailed = "failed to perform Update Shared Processor Pool Operation for pool %s with error %v"
 
 // start of Shared processor pool placement group Messages
-const GetSPPPlacementGroupOperationFailed = "failed to perform Get Shared Processor Pool Placement Group Operation for placement group %s with error %w"
-const CreateSPPPlacementGroupOperationFailed = "failed to perform Create Shared Processor Pool Placement Group Operation for cloud instance %s with error  %w"
-const DeleteSPPPlacementGroupOperationFailed = "failed to perform Delete Shared Processor Pool Placement Group Operation for placement group %s with error %w"
-const AddMemberSPPPlacementGroupOperationFailed = "failed to perform Add Member Operation for pool %s and shared processor pool placement group %s with error %w"
-const DeleteMemberSPPPlacementGroupOperationFailed = "failed to perform Delete Member Operation for pool %s and shared processor pool placement group %s with error %w"
+const GetSPPPlacementGroupOperationFailed = "failed to perform Get Shared Processor Pool Placement Group Operation for placement group %s with error %v"
+const CreateSPPPlacementGroupOperationFailed = "failed to perform Create Shared Processor Pool Placement Group Operation for cloud instance %s with error  %v"
+const DeleteSPPPlacementGroupOperationFailed = "failed to perform Delete Shared Processor Pool Placement Group Operation for placement group %s with error %v"
+const AddMemberSPPPlacementGroupOperationFailed = "failed to perform Add Member Operation for pool %s and shared processor pool placement group %s with error %v"
+const DeleteMemberSPPPlacementGroupOperationFailed = "failed to perform Delete Member Operation for pool %s and shared processor pool placement group %s with error %v"
 
 // ErrorTarget ...
 type ErrorTarget struct {

--- a/ibmpisession/utils.go
+++ b/ibmpisession/utils.go
@@ -96,3 +96,13 @@ func costructRegionFromZone(zone string) string {
 	reg, _ := regexp.Compile(regex)
 	return reg.ReplaceAllString(zone, "")
 }
+
+// SDKFailWithAPIError returns a custom error message if a HTTP error response 500 or greater is found
+func SDKFailWithAPIError(err error, errMessage string) error {
+	if apierr, ok := err.(*runtime.APIError); ok {
+		if apierr.Code >= 500 {
+			return fmt.Errorf("error: %v The server has encountered an unexpected error and is unable to fulfill the request", err)
+		}
+	}
+	return fmt.Errorf(errMessage)
+}


### PR DESCRIPTION
The API doesn't want to define greater than >= 500 error codes, so the SDK should at minimum print a boiler plate message in these situations to inform the user that a unexpected server error had occurred.

JIRA: https://jsw.ibm.com/browse/PPC-3009