### PR TITLE
Fix restore snapshot call

### DIFF
--- a/clients/instance/ibm-pi-instance.go
+++ b/clients/instance/ibm-pi-instance.go
@@ -253,18 +253,18 @@ func (f *IBMPIInstanceClient) GetSnapShotVM(id string) (*models.Snapshots, error
 }
 
 // Restore a Snapshot of an Instance
-func (f *IBMPIInstanceClient) RestoreSnapShotVM(id, snapshotid, restoreAction string, body *models.SnapshotRestore) (*models.Snapshot, error) {
+func (f *IBMPIInstanceClient) RestoreSnapShotVM(instanceID, snapshotID, restoreFailAction string, body *models.SnapshotRestore) (*models.Snapshot, error) {
 	params := p_cloud_p_vm_instances.NewPcloudPvminstancesSnapshotsRestorePostParams().
 		WithContext(f.ctx).WithTimeout(helpers.PICreateTimeOut).
-		WithCloudInstanceID(f.cloudInstanceID).WithPvmInstanceID(id).
-		WithSnapshotID(snapshotid).WithRestoreFailAction(&restoreAction).
+		WithCloudInstanceID(f.cloudInstanceID).WithPvmInstanceID(instanceID).
+		WithSnapshotID(snapshotID).WithRestoreFailAction(&restoreFailAction).
 		WithBody(body)
 	resp, err := f.session.Power.PCloudpVMInstances.PcloudPvminstancesSnapshotsRestorePost(params, f.session.AuthInfo(f.cloudInstanceID))
 	if err != nil {
-		return nil, ibmpisession.SDKFailWithAPIError(err, fmt.Errorf("failed to restrore the snapshot for the pvminstance %s: %w", id, err))
+		return nil, ibmpisession.SDKFailWithAPIError(err, fmt.Errorf("failed to restrore the snapshot for the pvminstance %s: %w", instanceID, err))
 	}
 	if resp == nil || resp.Payload == nil {
-		return nil, fmt.Errorf("failed to restrore the snapshot for the pvminstance %s", id)
+		return nil, fmt.Errorf("failed to restrore the snapshot for the pvminstance %s", instanceID)
 	}
 	return resp.Payload, nil
 }

--- a/clients/instance/ibm-pi-snapshot.go
+++ b/clients/instance/ibm-pi-snapshot.go
@@ -82,11 +82,12 @@ func (f *IBMPISnapshotClient) GetAll() (*models.Snapshots, error) {
 }
 
 // Restore a Snapshot
-func (f *IBMPISnapshotClient) Restore(instanceID, snapshotID, restoreFailAction string) (*models.Snapshot, error) {
+func (f *IBMPISnapshotClient) Restore(instanceID, snapshotID, restoreFailAction string, body *models.SnapshotRestore) (*models.Snapshot, error) {
 	params := p_cloud_p_vm_instances.NewPcloudPvminstancesSnapshotsRestorePostParams().
 		WithContext(f.ctx).WithTimeout(helpers.PICreateTimeOut).
 		WithCloudInstanceID(f.cloudInstanceID).WithPvmInstanceID(instanceID).
-		WithSnapshotID(snapshotID).WithRestoreFailAction(&restoreFailAction)
+		WithSnapshotID(snapshotID).WithRestoreFailAction(&restoreFailAction).
+		WithBody(body)
 	resp, err := f.session.Power.PCloudpVMInstances.PcloudPvminstancesSnapshotsRestorePost(params, f.session.AuthInfo(f.cloudInstanceID))
 	if err != nil {
 		return nil, ibmpisession.SDKFailWithAPIError(err, fmt.Errorf("failed to restore PI Snapshot %s of the instance %s: %w", snapshotID, instanceID, err))

--- a/clients/instance/ibm-pi-snapshot.go
+++ b/clients/instance/ibm-pi-snapshot.go
@@ -82,34 +82,34 @@ func (f *IBMPISnapshotClient) GetAll() (*models.Snapshots, error) {
 }
 
 // Restore a Snapshot
-func (f *IBMPISnapshotClient) Restore(instanceID, snapshotID, restoreFailAction string, body *models.SnapshotRestore) (*models.Snapshot, error) {
+func (f *IBMPISnapshotClient) Restore(id, snapshotID, restoreFailAction string, body *models.SnapshotRestore) (*models.Snapshot, error) {
 	params := p_cloud_p_vm_instances.NewPcloudPvminstancesSnapshotsRestorePostParams().
 		WithContext(f.ctx).WithTimeout(helpers.PICreateTimeOut).
-		WithCloudInstanceID(f.cloudInstanceID).WithPvmInstanceID(instanceID).
+		WithCloudInstanceID(f.cloudInstanceID).WithPvmInstanceID(id).
 		WithSnapshotID(snapshotID).WithRestoreFailAction(&restoreFailAction).
 		WithBody(body)
 	resp, err := f.session.Power.PCloudpVMInstances.PcloudPvminstancesSnapshotsRestorePost(params, f.session.AuthInfo(f.cloudInstanceID))
 	if err != nil {
-		return nil, ibmpisession.SDKFailWithAPIError(err, fmt.Errorf("failed to restore PI Snapshot %s of the instance %s: %w", snapshotID, instanceID, err))
+		return nil, ibmpisession.SDKFailWithAPIError(err, fmt.Errorf("failed to restore PI Snapshot %s of the instance %s: %w", snapshotID, id, err))
 	}
 	if resp == nil || resp.Payload == nil {
-		return nil, fmt.Errorf("failed to restore PI Snapshot %s of the instance %s", snapshotID, instanceID)
+		return nil, fmt.Errorf("failed to restore PI Snapshot %s of the instance %s", snapshotID, id)
 	}
 	return resp.Payload, nil
 }
 
 // Deprecated Restore function a Snapshot
-func (f *IBMPISnapshotClient) Create(instanceID, snapshotID string, body *models.SnapshotRestore) (*models.Snapshot, error) {
+func (f *IBMPISnapshotClient) Create(id, snapshotID string, body *models.SnapshotRestore) (*models.Snapshot, error) {
 	params := p_cloud_p_vm_instances.NewPcloudPvminstancesSnapshotsRestorePostParams().
 		WithContext(f.ctx).WithTimeout(helpers.PICreateTimeOut).
-		WithCloudInstanceID(f.cloudInstanceID).WithPvmInstanceID(instanceID).
+		WithCloudInstanceID(f.cloudInstanceID).WithPvmInstanceID(id).
 		WithSnapshotID(snapshotID).WithBody(body)
 	resp, err := f.session.Power.PCloudpVMInstances.PcloudPvminstancesSnapshotsRestorePost(params, f.session.AuthInfo(f.cloudInstanceID))
 	if err != nil {
-		return nil, ibmpisession.SDKFailWithAPIError(err, fmt.Errorf("failed to restore PI Snapshot %s of the instance %s: %w", snapshotID, instanceID, err))
+		return nil, ibmpisession.SDKFailWithAPIError(err, fmt.Errorf("failed to restore PI Snapshot %s of the instance %s: %w", snapshotID, id, err))
 	}
 	if resp == nil || resp.Payload == nil {
-		return nil, fmt.Errorf("failed to restore PI Snapshot %s of the instance %s", snapshotID, instanceID)
+		return nil, fmt.Errorf("failed to restore PI Snapshot %s of the instance %s", snapshotID, id)
 	}
 	return resp.Payload, nil
 }

--- a/clients/instance/ibm-pi-snapshot.go
+++ b/clients/instance/ibm-pi-snapshot.go
@@ -97,3 +97,19 @@ func (f *IBMPISnapshotClient) Restore(instanceID, snapshotID, restoreFailAction 
 	}
 	return resp.Payload, nil
 }
+
+// Deprecated Restore function a Snapshot
+func (f *IBMPISnapshotClient) Create(instanceID, snapshotID string, body *models.SnapshotRestore) (*models.Snapshot, error) {
+	params := p_cloud_p_vm_instances.NewPcloudPvminstancesSnapshotsRestorePostParams().
+		WithContext(f.ctx).WithTimeout(helpers.PICreateTimeOut).
+		WithCloudInstanceID(f.cloudInstanceID).WithPvmInstanceID(instanceID).
+		WithSnapshotID(snapshotID).WithBody(body)
+	resp, err := f.session.Power.PCloudpVMInstances.PcloudPvminstancesSnapshotsRestorePost(params, f.session.AuthInfo(f.cloudInstanceID))
+	if err != nil {
+		return nil, ibmpisession.SDKFailWithAPIError(err, fmt.Errorf("failed to restore PI Snapshot %s of the instance %s: %w", snapshotID, instanceID, err))
+	}
+	if resp == nil || resp.Payload == nil {
+		return nil, fmt.Errorf("failed to restore PI Snapshot %s of the instance %s", snapshotID, instanceID)
+	}
+	return resp.Payload, nil
+}

--- a/clients/instance/ibm-pi-snapshot.go
+++ b/clients/instance/ibm-pi-snapshot.go
@@ -81,8 +81,8 @@ func (f *IBMPISnapshotClient) GetAll() (*models.Snapshots, error) {
 	return resp.Payload, nil
 }
 
-// Create or Restore a Snapshot
-func (f *IBMPISnapshotClient) Create(instanceID, snapshotID, restoreFailAction string) (*models.Snapshot, error) {
+// Restore a Snapshot
+func (f *IBMPISnapshotClient) Restore(instanceID, snapshotID, restoreFailAction string) (*models.Snapshot, error) {
 	params := p_cloud_p_vm_instances.NewPcloudPvminstancesSnapshotsRestorePostParams().
 		WithContext(f.ctx).WithTimeout(helpers.PICreateTimeOut).
 		WithCloudInstanceID(f.cloudInstanceID).WithPvmInstanceID(instanceID).


### PR DESCRIPTION
The restore snapshot call is incorrectly labeled as "create" even though that is not the endpoint it calls, and there is a separate create snapshot call in the ibm-pi-instance.go file.