### PR TITLE
Add checksum gates for powervs

### DIFF
--- a/clients/instance/ibm-pi-image.go
+++ b/clients/instance/ibm-pi-image.go
@@ -79,6 +79,10 @@ func (f *IBMPIImageClient) Create(body *models.CreateImage) (*models.Image, erro
 
 // Import an Image
 func (f *IBMPIImageClient) CreateCosImage(body *models.CreateCosImageImportJob) (imageJob *models.JobReference, err error) {
+	// Check for satellite differences in this endpoint
+	if !f.session.IsOnPrem() && body.Checksum {
+		return nil, fmt.Errorf("checksum parameter is not supported off-premise")
+	}
 	params := p_cloud_images.NewPcloudV1CloudinstancesCosimagesPostParams().
 		WithContext(f.ctx).WithTimeout(helpers.PICreateTimeOut).
 		WithCloudInstanceID(f.cloudInstanceID).WithBody(body)
@@ -94,6 +98,10 @@ func (f *IBMPIImageClient) CreateCosImage(body *models.CreateCosImageImportJob) 
 
 // Export an Image
 func (f *IBMPIImageClient) ExportImage(id string, body *models.ExportImage) (*models.JobReference, error) {
+	// Check for satellite differences in this endpoint
+	if !f.session.IsOnPrem() && body.Checksum {
+		return nil, fmt.Errorf("checksum parameter is not supported off-premise")
+	}
 	params := p_cloud_images.NewPcloudV2ImagesExportPostParams().
 		WithContext(f.ctx).WithTimeout(helpers.PICreateTimeOut).
 		WithCloudInstanceID(f.cloudInstanceID).WithImageID(id).WithBody(body)

--- a/clients/instance/ibm-pi-instance.go
+++ b/clients/instance/ibm-pi-instance.go
@@ -176,6 +176,10 @@ func (f *IBMPIInstanceClient) UpdateConsoleLanguage(id string, body *models.Cons
 
 // Capture an Instance
 func (f *IBMPIInstanceClient) CaptureInstanceToImageCatalog(id string, body *models.PVMInstanceCapture) error {
+	// Check for satellite differences in this endpoint
+	if !f.session.IsOnPrem() && body.Checksum {
+		return fmt.Errorf("checksum parameter is not supported off-premise")
+	}
 	params := p_cloud_p_vm_instances.NewPcloudPvminstancesCapturePostParams().
 		WithContext(f.ctx).WithTimeout(helpers.PIGetTimeOut).
 		WithCloudInstanceID(f.cloudInstanceID).WithPvmInstanceID(id).


### PR DESCRIPTION
The checksum option will only be available on stratos at first later. Later it will be added to PowerVS, so it needs to be gated in the meantime. 
JIRA: https://jsw.ibm.com/browse/PPC-4441