### PR TITLE
Get the supported storage tiers of a cloud instance

### DIFF
--- a/clients/instance/ibm-pi-storage-tiers.go
+++ b/clients/instance/ibm-pi-storage-tiers.go
@@ -1,0 +1,40 @@
+package instance
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/IBM-Cloud/power-go-client/errors"
+	"github.com/IBM-Cloud/power-go-client/helpers"
+
+	"github.com/IBM-Cloud/power-go-client/ibmpisession"
+	"github.com/IBM-Cloud/power-go-client/power/client/p_cloud_storage_tiers"
+	"github.com/IBM-Cloud/power-go-client/power/models"
+)
+
+// IBMPIStorageTierClient
+type IBMPIStorageTierClient struct {
+	IBMPIClient
+}
+
+// NewIBMPIStorageTierClient
+func NewIBMPIStorageTierClient(ctx context.Context, sess *ibmpisession.IBMPISession, cloudInstanceID string) *IBMPIStorageTierClient {
+	return &IBMPIStorageTierClient{
+		*NewIBMPIClient(ctx, sess, cloudInstanceID),
+	}
+}
+
+// Gets all the storage tiers associated to the cloud instance.
+func (f *IBMPIStorageTierClient) GetAll() (models.RegionStorageTiers, error) {
+	params := p_cloud_storage_tiers.NewPcloudCloudinstancesStoragetiersGetallParams().
+		WithContext(f.ctx).WithTimeout(helpers.PIGetTimeOut).
+		WithCloudInstanceID(f.cloudInstanceID)
+	resp, err := f.session.Power.PCloudStorageTiers.PcloudCloudinstancesStoragetiersGetall(params, f.session.AuthInfo(f.cloudInstanceID))
+	if err != nil {
+		return nil, ibmpisession.SDKFailWithAPIError(err, fmt.Errorf(errors.GetAllStorageTiersOperationFailed, f.cloudInstanceID, err))
+	}
+	if resp == nil || resp.Payload == nil {
+		return nil, fmt.Errorf("failed to get all storage tiers")
+	}
+	return resp.Payload, nil
+}

--- a/errors/errors.go
+++ b/errors/errors.go
@@ -121,11 +121,14 @@ const DeleteSPPPlacementGroupOperationFailed = "failed to perform Delete Shared 
 const AddMemberSPPPlacementGroupOperationFailed = "failed to perform Add Member Operation for pool %s and shared processor pool placement group %s with error %w"
 const DeleteMemberSPPPlacementGroupOperationFailed = "failed to perform Delete Member Operation for pool %s and shared processor pool placement group %s with error %w"
 
-// start of workspaces
+// start of Workspaces Messages
 const GetWorkspaceOperationFailed = "failed to perform Get Workspace Operation for id %s with error %w"
 
-// Datacenter
+// start of Datacenter Messages
 const GetDatacenterOperationFailed = "failed to perform Get Datacenter Operation for id %s with error %w"
+
+// start of StorageTier Messages
+const GetAllStorageTiersOperationFailed = "failed to perform get all Storage Tiers Operation for id %s with error %w"
 
 // ErrorTarget ...
 type ErrorTarget struct {


### PR DESCRIPTION
Changes:
* Introduce a storage tier client to retrieve the storage tiers available to a associated cloud instance ID.