### PR TITLE
Add deployment-type safeguard for stratos

### DIFF
--- a/clients/instance/ibm-pi-instance.go
+++ b/clients/instance/ibm-pi-instance.go
@@ -55,8 +55,8 @@ func (f *IBMPIInstanceClient) GetAll() (*models.PVMInstances, error) {
 // Create an Instance
 func (f *IBMPIInstanceClient) Create(body *models.PVMInstanceCreate) (*models.PVMInstanceList, error) {
 	// Check for satellite differences in this endpoint
-	if f.session.IsOnPrem() && body.DeploymentTarget != nil {
-		return nil, fmt.Errorf("deployment target parameter is not supported in satellite location, check documentation")
+	if f.session.IsOnPrem() && (body.DeploymentTarget != nil || body.DeploymentType != "") {
+		return nil, fmt.Errorf("deployment target and deployment type parameters are not supported in satellite location, check documentation")
 	}
 	params := p_cloud_p_vm_instances.NewPcloudPvminstancesPostParams().
 		WithContext(f.ctx).WithTimeout(helpers.PICreateTimeOut).


### PR DESCRIPTION
Missing safeguard from a while ago. Since these are redundant to an extent, I don't think we need to rush to merge it into the Q3 release.