### PR TITLE
Remove Stratos safeguards for GRS changes

### DIFF
--- a/clients/instance/ibm-pi-dr-location.go
+++ b/clients/instance/ibm-pi-dr-location.go
@@ -25,9 +25,6 @@ func NewIBMPIDisasterRecoveryLocationClient(ctx context.Context, sess *ibmpisess
 
 // Get the disaster recovery site details for the current location
 func (f *IBMPIDisasterRecoveryLocationClient) Get() (*models.DisasterRecoveryLocation, error) {
-	if f.session.IsOnPrem() {
-		return nil, fmt.Errorf("operation not supported in satellite location, check documentation")
-	}
 	params := p_cloud_disaster_recovery.NewPcloudLocationsDisasterrecoveryGetParams().
 		WithContext(f.ctx).WithTimeout(helpers.PIGetTimeOut).
 		WithCloudInstanceID(f.cloudInstanceID)
@@ -43,9 +40,6 @@ func (f *IBMPIDisasterRecoveryLocationClient) Get() (*models.DisasterRecoveryLoc
 
 // Get all disaster recovery locations supported by Power Virtual Server
 func (f *IBMPIDisasterRecoveryLocationClient) GetAll() (*models.DisasterRecoveryLocations, error) {
-	if f.session.IsOnPrem() {
-		return nil, fmt.Errorf("operation not supported in satellite location, check documentation")
-	}
 	params := p_cloud_disaster_recovery.NewPcloudLocationsDisasterrecoveryGetallParams().
 		WithContext(f.ctx).WithTimeout(helpers.PIGetTimeOut)
 	resp, err := f.session.Power.PCloudDisasterRecovery.PcloudLocationsDisasterrecoveryGetall(params, f.session.AuthInfo(f.cloudInstanceID))

--- a/clients/instance/ibm-pi-volume-onboarding.go
+++ b/clients/instance/ibm-pi-volume-onboarding.go
@@ -25,9 +25,6 @@ func NewIBMPIVolumeOnboardingClient(ctx context.Context, sess *ibmpisession.IBMP
 
 // Get the information of volume onboarding operation
 func (f *IBMPIVolumeOnboardingClient) Get(id string) (*models.VolumeOnboarding, error) {
-	if f.session.IsOnPrem() {
-		return nil, fmt.Errorf("operation not supported in satellite location, check documentation")
-	}
 	params := p_cloud_volume_onboarding.NewPcloudVolumeOnboardingGetParams().
 		WithContext(f.ctx).WithTimeout(helpers.PIGetTimeOut).
 		WithCloudInstanceID(f.cloudInstanceID).WithVolumeOnboardingID(id)
@@ -43,9 +40,6 @@ func (f *IBMPIVolumeOnboardingClient) Get(id string) (*models.VolumeOnboarding, 
 
 // Get All volume onboardings for this cloud instance
 func (f *IBMPIVolumeOnboardingClient) GetAll() (*models.VolumeOnboardings, error) {
-	if f.session.IsOnPrem() {
-		return nil, fmt.Errorf("operation not supported in satellite location, check documentation")
-	}
 	params := p_cloud_volume_onboarding.NewPcloudVolumeOnboardingGetallParams().
 		WithContext(f.ctx).WithTimeout(helpers.PIGetTimeOut).
 		WithCloudInstanceID(f.cloudInstanceID)
@@ -61,9 +55,6 @@ func (f *IBMPIVolumeOnboardingClient) GetAll() (*models.VolumeOnboardings, error
 
 // Onboard auxiliary volumes to target site
 func (f *IBMPIVolumeOnboardingClient) CreateVolumeOnboarding(body *models.VolumeOnboardingCreate) (*models.VolumeOnboardingCreateResponse, error) {
-	if f.session.IsOnPrem() {
-		return nil, fmt.Errorf("operation not supported in satellite location, check documentation")
-	}
 	params := p_cloud_volume_onboarding.NewPcloudVolumeOnboardingPostParams().
 		WithContext(f.ctx).WithTimeout(helpers.PICreateTimeOut).
 		WithCloudInstanceID(f.cloudInstanceID).WithBody(body)


### PR DESCRIPTION
Removes safeguards for volume-onboarding and disaster-recovery APIs that will be available to on prem for Q4.