### PR TITLE
Standardize off on prem error

### DIFF
--- a/clients/instance/ibm-pi-clonevolumes.go
+++ b/clients/instance/ibm-pi-clonevolumes.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 
 	"github.com/IBM-Cloud/power-go-client/errors"
-
 	"github.com/IBM-Cloud/power-go-client/helpers"
 	"github.com/IBM-Cloud/power-go-client/ibmpisession"
 	"github.com/IBM-Cloud/power-go-client/power/client/p_cloud_volumes"

--- a/clients/instance/ibm-pi-cloud-connection.go
+++ b/clients/instance/ibm-pi-cloud-connection.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/IBM-Cloud/power-go-client/errors"
 	"github.com/IBM-Cloud/power-go-client/helpers"
-
 	"github.com/IBM-Cloud/power-go-client/ibmpisession"
 	"github.com/IBM-Cloud/power-go-client/power/client/p_cloud_cloud_connections"
 	"github.com/IBM-Cloud/power-go-client/power/models"
@@ -27,7 +26,7 @@ func NewIBMPICloudConnectionClient(ctx context.Context, sess *ibmpisession.IBMPI
 // Create a Cloud Connection
 func (f *IBMPICloudConnectionClient) Create(body *models.CloudConnectionCreate) (*models.CloudConnection, *models.CloudConnectionCreateResponse, error) {
 	if f.session.IsOnPrem() {
-		return nil, nil, fmt.Errorf("operation not supported in satellite location, check documentation")
+		return nil, nil, fmt.Errorf(helpers.NotOnPremSupported)
 	}
 	params := p_cloud_cloud_connections.NewPcloudCloudconnectionsPostParams().
 		WithContext(f.ctx).WithTimeout(helpers.PICreateTimeOut).
@@ -51,7 +50,7 @@ func (f *IBMPICloudConnectionClient) Create(body *models.CloudConnectionCreate) 
 // Get a Cloud Connection
 func (f *IBMPICloudConnectionClient) Get(id string) (*models.CloudConnection, error) {
 	if f.session.IsOnPrem() {
-		return nil, fmt.Errorf("operation not supported in satellite location, check documentation")
+		return nil, fmt.Errorf(helpers.NotOnPremSupported)
 	}
 	params := p_cloud_cloud_connections.NewPcloudCloudconnectionsGetParams().
 		WithContext(f.ctx).WithTimeout(helpers.PIGetTimeOut).
@@ -69,7 +68,7 @@ func (f *IBMPICloudConnectionClient) Get(id string) (*models.CloudConnection, er
 // Get All Cloud Connections
 func (f *IBMPICloudConnectionClient) GetAll() (*models.CloudConnections, error) {
 	if f.session.IsOnPrem() {
-		return nil, fmt.Errorf("operation not supported in satellite location, check documentation")
+		return nil, fmt.Errorf(helpers.NotOnPremSupported)
 	}
 	params := p_cloud_cloud_connections.NewPcloudCloudconnectionsGetallParams().
 		WithContext(f.ctx).WithTimeout(helpers.PIGetTimeOut).
@@ -87,7 +86,7 @@ func (f *IBMPICloudConnectionClient) GetAll() (*models.CloudConnections, error) 
 // Update a Cloud Connection
 func (f *IBMPICloudConnectionClient) Update(id string, body *models.CloudConnectionUpdate) (*models.CloudConnection, *models.JobReference, error) {
 	if f.session.IsOnPrem() {
-		return nil, nil, fmt.Errorf("operation not supported in satellite location, check documentation")
+		return nil, nil, fmt.Errorf(helpers.NotOnPremSupported)
 	}
 	params := p_cloud_cloud_connections.NewPcloudCloudconnectionsPutParams().
 		WithContext(f.ctx).WithTimeout(helpers.PIUpdateTimeOut).
@@ -109,7 +108,7 @@ func (f *IBMPICloudConnectionClient) Update(id string, body *models.CloudConnect
 // Delete a Cloud Connection
 func (f *IBMPICloudConnectionClient) Delete(id string) (*models.JobReference, error) {
 	if f.session.IsOnPrem() {
-		return nil, fmt.Errorf("operation not supported in satellite location, check documentation")
+		return nil, fmt.Errorf(helpers.NotOnPremSupported)
 	}
 	params := p_cloud_cloud_connections.NewPcloudCloudconnectionsDeleteParams().
 		WithContext(f.ctx).WithTimeout(helpers.PIDeleteTimeOut).
@@ -127,7 +126,7 @@ func (f *IBMPICloudConnectionClient) Delete(id string) (*models.JobReference, er
 // Add a Network to a Cloud Connection
 func (f *IBMPICloudConnectionClient) AddNetwork(id, networkID string) (models.Object, *models.JobReference, error) {
 	if f.session.IsOnPrem() {
-		return nil, nil, fmt.Errorf("operation not supported in satellite location, check documentation")
+		return nil, nil, fmt.Errorf(helpers.NotOnPremSupported)
 	}
 	params := p_cloud_cloud_connections.NewPcloudCloudconnectionsNetworksPutParams().
 		WithContext(f.ctx).WithTimeout(helpers.PIUpdateTimeOut).
@@ -149,7 +148,7 @@ func (f *IBMPICloudConnectionClient) AddNetwork(id, networkID string) (models.Ob
 // Delete a Network from a Cloud Connection
 func (f *IBMPICloudConnectionClient) DeleteNetwork(id, networkID string) (models.Object, *models.JobReference, error) {
 	if f.session.IsOnPrem() {
-		return nil, nil, fmt.Errorf("operation not supported in satellite location, check documentation")
+		return nil, nil, fmt.Errorf(helpers.NotOnPremSupported)
 	}
 	params := p_cloud_cloud_connections.NewPcloudCloudconnectionsNetworksDeleteParams().
 		WithContext(f.ctx).WithTimeout(helpers.PIDeleteTimeOut).
@@ -171,7 +170,7 @@ func (f *IBMPICloudConnectionClient) DeleteNetwork(id, networkID string) (models
 // Get all VPCs for a Cloud Instance
 func (f *IBMPICloudConnectionClient) GetVPC() (*models.CloudConnectionVirtualPrivateClouds, error) {
 	if f.session.IsOnPrem() {
-		return nil, fmt.Errorf("operation not supported in satellite location, check documentation")
+		return nil, fmt.Errorf(helpers.NotOnPremSupported)
 	}
 	params := p_cloud_cloud_connections.NewPcloudCloudconnectionsVirtualprivatecloudsGetallParams().
 		WithContext(f.ctx).WithTimeout(helpers.PIGetTimeOut).

--- a/clients/instance/ibm-pi-cloud-instance.go
+++ b/clients/instance/ibm-pi-cloud-instance.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/IBM-Cloud/power-go-client/errors"
 	"github.com/IBM-Cloud/power-go-client/helpers"
-
 	"github.com/IBM-Cloud/power-go-client/ibmpisession"
 	"github.com/IBM-Cloud/power-go-client/power/client/p_cloud_instances"
 	"github.com/IBM-Cloud/power-go-client/power/models"

--- a/clients/instance/ibm-pi-dhcp.go
+++ b/clients/instance/ibm-pi-dhcp.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/IBM-Cloud/power-go-client/errors"
 	"github.com/IBM-Cloud/power-go-client/helpers"
-
 	"github.com/IBM-Cloud/power-go-client/ibmpisession"
 	"github.com/IBM-Cloud/power-go-client/power/client/p_cloud_service_d_h_c_p"
 	"github.com/IBM-Cloud/power-go-client/power/models"

--- a/clients/instance/ibm-pi-host-groups.go
+++ b/clients/instance/ibm-pi-host-groups.go
@@ -25,7 +25,7 @@ func NewIBMPIHostGroupsClient(ctx context.Context, sess *ibmpisession.IBMPISessi
 // Get All available hosts
 func (f *IBMPIHostGroupsClient) GetAvailableHosts() (models.AvailableHostList, error) {
 	if f.session.IsOnPrem() {
-		return nil, fmt.Errorf("operation not supported in satellite location, check documentation")
+		return nil, fmt.Errorf(helpers.NotOnPremSupported)
 	}
 	params := host_groups.NewV1AvailableHostsParams().WithContext(f.ctx).WithTimeout(helpers.PIGetTimeOut)
 	resp, err := f.session.Power.HostGroups.V1AvailableHosts(params, f.session.AuthInfo(f.cloudInstanceID))
@@ -42,7 +42,7 @@ func (f *IBMPIHostGroupsClient) GetAvailableHosts() (models.AvailableHostList, e
 // Get all host groups
 func (f *IBMPIHostGroupsClient) GetHostGroups() (models.HostGroupList, error) {
 	if f.session.IsOnPrem() {
-		return nil, fmt.Errorf("operation not supported in satellite location, check documentation")
+		return nil, fmt.Errorf(helpers.NotOnPremSupported)
 	}
 	params := host_groups.NewV1HostGroupsGetParams().WithContext(f.ctx).WithTimeout(helpers.PIGetTimeOut)
 	resp, err := f.session.Power.HostGroups.V1HostGroupsGet(params, f.session.AuthInfo(f.cloudInstanceID))
@@ -59,7 +59,7 @@ func (f *IBMPIHostGroupsClient) GetHostGroups() (models.HostGroupList, error) {
 // Create a host group
 func (f *IBMPIHostGroupsClient) CreateHostGroup(body *models.HostGroupCreate) (*models.HostGroup, error) {
 	if f.session.IsOnPrem() {
-		return nil, fmt.Errorf("operation not supported in satellite location, check documentation")
+		return nil, fmt.Errorf(helpers.NotOnPremSupported)
 	}
 	params := host_groups.NewV1HostGroupsPostParams().WithContext(f.ctx).WithTimeout(helpers.PICreateTimeOut).WithBody(body)
 	resp, err := f.session.Power.HostGroups.V1HostGroupsPost(params, f.session.AuthInfo(f.cloudInstanceID))
@@ -76,7 +76,7 @@ func (f *IBMPIHostGroupsClient) CreateHostGroup(body *models.HostGroupCreate) (*
 // Update a host group
 func (f *IBMPIHostGroupsClient) UpdateHostGroup(body *models.HostGroupShareOp, id string) (*models.HostGroup, error) {
 	if f.session.IsOnPrem() {
-		return nil, fmt.Errorf("operation not supported in satellite location, check documentation")
+		return nil, fmt.Errorf(helpers.NotOnPremSupported)
 	}
 	params := host_groups.NewV1HostGroupsIDPutParams().WithContext(f.ctx).WithTimeout(helpers.PICreateTimeOut).WithBody(body).WithHostGroupID(id)
 	resp, err := f.session.Power.HostGroups.V1HostGroupsIDPut(params, f.session.AuthInfo(f.cloudInstanceID))
@@ -93,7 +93,7 @@ func (f *IBMPIHostGroupsClient) UpdateHostGroup(body *models.HostGroupShareOp, i
 // Get a host group
 func (f *IBMPIHostGroupsClient) GetHostGroup(id string) (*models.HostGroup, error) {
 	if f.session.IsOnPrem() {
-		return nil, fmt.Errorf("operation not supported in satellite location, check documentation")
+		return nil, fmt.Errorf(helpers.NotOnPremSupported)
 	}
 	params := host_groups.NewV1HostGroupsIDGetParams().WithContext(f.ctx).WithTimeout(helpers.PIGetTimeOut).WithHostGroupID(id)
 	resp, err := f.session.Power.HostGroups.V1HostGroupsIDGet(params, f.session.AuthInfo(f.cloudInstanceID))
@@ -110,7 +110,7 @@ func (f *IBMPIHostGroupsClient) GetHostGroup(id string) (*models.HostGroup, erro
 // Get  all hosts
 func (f *IBMPIHostGroupsClient) GetHosts() (models.HostList, error) {
 	if f.session.IsOnPrem() {
-		return nil, fmt.Errorf("operation not supported in satellite location, check documentation")
+		return nil, fmt.Errorf(helpers.NotOnPremSupported)
 	}
 	hostReference := true
 	params := host_groups.NewV1HostsGetParams().WithContext(f.ctx).WithTimeout(helpers.PIGetTimeOut)
@@ -129,7 +129,7 @@ func (f *IBMPIHostGroupsClient) GetHosts() (models.HostList, error) {
 // Create a host
 func (f *IBMPIHostGroupsClient) CreateHost(body *models.HostCreate) (models.HostList, error) {
 	if f.session.IsOnPrem() {
-		return nil, fmt.Errorf("operation not supported in satellite location, check documentation")
+		return nil, fmt.Errorf(helpers.NotOnPremSupported)
 	}
 	params := host_groups.NewV1HostsPostParams().WithContext(f.ctx).WithTimeout(helpers.PIGetTimeOut).WithBody(body)
 	resp, err := f.session.Power.HostGroups.V1HostsPost(params, f.session.AuthInfo(f.cloudInstanceID))
@@ -146,7 +146,7 @@ func (f *IBMPIHostGroupsClient) CreateHost(body *models.HostCreate) (models.Host
 // Get a host
 func (f *IBMPIHostGroupsClient) GetHost(id string) (*models.Host, error) {
 	if f.session.IsOnPrem() {
-		return nil, fmt.Errorf("operation not supported in satellite location, check documentation")
+		return nil, fmt.Errorf(helpers.NotOnPremSupported)
 	}
 	hostReference := true
 	params := host_groups.NewV1HostsIDGetParams().WithContext(f.ctx).WithTimeout(helpers.PIGetTimeOut).WithHostID(id)
@@ -165,7 +165,7 @@ func (f *IBMPIHostGroupsClient) GetHost(id string) (*models.Host, error) {
 // Update a host
 func (f *IBMPIHostGroupsClient) UpdateHost(body *models.HostPut, id string) (*models.Host, error) {
 	if f.session.IsOnPrem() {
-		return nil, fmt.Errorf("operation not supported in satellite location, check documentation")
+		return nil, fmt.Errorf(helpers.NotOnPremSupported)
 	}
 	params := host_groups.NewV1HostsIDPutParams().WithContext(f.ctx).WithTimeout(helpers.PIGetTimeOut).WithHostID(id).WithBody(body)
 	resp, err := f.session.Power.HostGroups.V1HostsIDPut(params, f.session.AuthInfo(f.cloudInstanceID))
@@ -182,7 +182,7 @@ func (f *IBMPIHostGroupsClient) UpdateHost(body *models.HostPut, id string) (*mo
 // Delete a host
 func (f *IBMPIHostGroupsClient) DeleteHost(id string) error {
 	if f.session.IsOnPrem() {
-		return fmt.Errorf("operation not supported in satellite location, check documentation")
+		return fmt.Errorf(helpers.NotOnPremSupported)
 	}
 	params := host_groups.NewV1HostsIDDeleteParams().WithContext(f.ctx).WithTimeout(helpers.PIGetTimeOut).WithHostID(id)
 	resp, err := f.session.Power.HostGroups.V1HostsIDDelete(params, f.session.AuthInfo(f.cloudInstanceID))

--- a/clients/instance/ibm-pi-image.go
+++ b/clients/instance/ibm-pi-image.go
@@ -4,14 +4,12 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/IBM/go-sdk-core/v5/core"
-
 	"github.com/IBM-Cloud/power-go-client/errors"
-
 	"github.com/IBM-Cloud/power-go-client/helpers"
 	"github.com/IBM-Cloud/power-go-client/ibmpisession"
 	"github.com/IBM-Cloud/power-go-client/power/client/p_cloud_images"
 	"github.com/IBM-Cloud/power-go-client/power/models"
+	"github.com/IBM/go-sdk-core/v5/core"
 )
 
 // IBMPIImageClient
@@ -81,7 +79,7 @@ func (f *IBMPIImageClient) Create(body *models.CreateImage) (*models.Image, erro
 func (f *IBMPIImageClient) CreateCosImage(body *models.CreateCosImageImportJob) (imageJob *models.JobReference, err error) {
 	// Check for satellite differences in this endpoint
 	if !f.session.IsOnPrem() && body.Checksum {
-		return nil, fmt.Errorf("checksum parameter is not supported off-premise")
+		return nil, fmt.Errorf("checksum parameter is not supported in off-prem location")
 	}
 	params := p_cloud_images.NewPcloudV1CloudinstancesCosimagesPostParams().
 		WithContext(f.ctx).WithTimeout(helpers.PICreateTimeOut).
@@ -100,7 +98,7 @@ func (f *IBMPIImageClient) CreateCosImage(body *models.CreateCosImageImportJob) 
 func (f *IBMPIImageClient) ExportImage(id string, body *models.ExportImage) (*models.JobReference, error) {
 	// Check for satellite differences in this endpoint
 	if !f.session.IsOnPrem() && body.Checksum {
-		return nil, fmt.Errorf("checksum parameter is not supported off-premise")
+		return nil, fmt.Errorf("checksum parameter is not supported in off-prem location")
 	}
 	params := p_cloud_images.NewPcloudV2ImagesExportPostParams().
 		WithContext(f.ctx).WithTimeout(helpers.PICreateTimeOut).

--- a/clients/instance/ibm-pi-instance.go
+++ b/clients/instance/ibm-pi-instance.go
@@ -56,7 +56,7 @@ func (f *IBMPIInstanceClient) GetAll() (*models.PVMInstances, error) {
 func (f *IBMPIInstanceClient) Create(body *models.PVMInstanceCreate) (*models.PVMInstanceList, error) {
 	// Check for satellite differences in this endpoint
 	if f.session.IsOnPrem() && (body.DeploymentTarget != nil || body.DeploymentType != "") {
-		return nil, fmt.Errorf("deployment target and deployment type parameters are not supported in satellite location, check documentation")
+		return nil, fmt.Errorf("deployment target and deployment type parameters are not supported in satellite location")
 	}
 	params := p_cloud_p_vm_instances.NewPcloudPvminstancesPostParams().
 		WithContext(f.ctx).WithTimeout(helpers.PICreateTimeOut).
@@ -105,7 +105,7 @@ func (f *IBMPIInstanceClient) DeleteWithBody(id string, body *models.PVMInstance
 func (f *IBMPIInstanceClient) Update(id string, body *models.PVMInstanceUpdate) (*models.PVMInstanceUpdateResponse, error) {
 	// Check for satellite differences in this endpoint
 	if f.session.IsOnPrem() && body.SapProfileID != "" {
-		return nil, fmt.Errorf("sap profile id parameter is not supported in satellite location, check documentation")
+		return nil, fmt.Errorf("sap profile id parameter is not supported in satellite location")
 	}
 	params := p_cloud_p_vm_instances.NewPcloudPvminstancesPutParams().
 		WithContext(f.ctx).WithTimeout(helpers.PICreateTimeOut).
@@ -152,7 +152,7 @@ func (f *IBMPIInstanceClient) PostConsoleURL(id string) (*models.PVMInstanceCons
 // List the available Console Languages for an Instance
 func (f *IBMPIInstanceClient) GetConsoleLanguages(id string) (*models.ConsoleLanguages, error) {
 	if f.session.IsOnPrem() {
-		return nil, fmt.Errorf("operation not supported in satellite location, check documentation")
+		return nil, fmt.Errorf(helpers.NotOnPremSupported)
 	}
 	params := p_cloud_p_vm_instances.NewPcloudPvminstancesConsoleGetParams().
 		WithContext(f.ctx).WithTimeout(helpers.PIGetTimeOut).
@@ -170,7 +170,7 @@ func (f *IBMPIInstanceClient) GetConsoleLanguages(id string) (*models.ConsoleLan
 // Update the available Console Languages for an Instance
 func (f *IBMPIInstanceClient) UpdateConsoleLanguage(id string, body *models.ConsoleLanguage) (*models.ConsoleLanguage, error) {
 	if f.session.IsOnPrem() {
-		return nil, fmt.Errorf("operation not supported in satellite location, check documentation")
+		return nil, fmt.Errorf(helpers.NotOnPremSupported)
 	}
 	params := p_cloud_p_vm_instances.NewPcloudPvminstancesConsolePutParams().
 		WithContext(f.ctx).WithTimeout(helpers.PIUpdateTimeOut).
@@ -190,7 +190,7 @@ func (f *IBMPIInstanceClient) UpdateConsoleLanguage(id string, body *models.Cons
 func (f *IBMPIInstanceClient) CaptureInstanceToImageCatalog(id string, body *models.PVMInstanceCapture) error {
 	// Check for satellite differences in this endpoint
 	if !f.session.IsOnPrem() && body.Checksum {
-		return fmt.Errorf("checksum parameter is not supported off-premise")
+		return fmt.Errorf("checksum parameter is not supported in off-prem location")
 	}
 	params := p_cloud_p_vm_instances.NewPcloudPvminstancesCapturePostParams().
 		WithContext(f.ctx).WithTimeout(helpers.PIGetTimeOut).

--- a/clients/instance/ibm-pi-job.go
+++ b/clients/instance/ibm-pi-job.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/IBM-Cloud/power-go-client/errors"
 	"github.com/IBM-Cloud/power-go-client/helpers"
-
 	"github.com/IBM-Cloud/power-go-client/ibmpisession"
 	"github.com/IBM-Cloud/power-go-client/power/client/p_cloud_jobs"
 	"github.com/IBM-Cloud/power-go-client/power/models"

--- a/clients/instance/ibm-pi-key.go
+++ b/clients/instance/ibm-pi-key.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/IBM-Cloud/power-go-client/errors"
 	"github.com/IBM-Cloud/power-go-client/helpers"
-
 	"github.com/IBM-Cloud/power-go-client/ibmpisession"
 	"github.com/IBM-Cloud/power-go-client/power/client/p_cloud_tenants_ssh_keys"
 	"github.com/IBM-Cloud/power-go-client/power/models"

--- a/clients/instance/ibm-pi-network-address-group.go
+++ b/clients/instance/ibm-pi-network-address-group.go
@@ -26,7 +26,7 @@ func NewIBMPINetworkAddressGroupClient(ctx context.Context, sess *ibmpisession.I
 func (f *IBMPINetworkAddressGroupClient) Create(body *models.NetworkAddressGroupCreate) (*models.NetworkAddressGroup, error) {
 	// Add check for on-prem location
 	if f.session.IsOnPrem() {
-		return nil, fmt.Errorf("operation not supported in satellite location.")
+		return nil, fmt.Errorf(helpers.NotOnPremSupported)
 	}
 	params := network_address_groups.NewV1NetworkAddressGroupsPostParams().WithContext(f.ctx).WithTimeout(helpers.PICreateTimeOut).WithBody(body)
 	postok, postcreated, err := f.session.Power.NetworkAddressGroups.V1NetworkAddressGroupsPost(params, f.session.AuthInfo(f.cloudInstanceID))
@@ -46,7 +46,7 @@ func (f *IBMPINetworkAddressGroupClient) Create(body *models.NetworkAddressGroup
 func (f *IBMPINetworkAddressGroupClient) GetAll() (*models.NetworkAddressGroups, error) {
 	// Add check for on-prem location
 	if f.session.IsOnPrem() {
-		return nil, fmt.Errorf("operation not supported in satellite location.")
+		return nil, fmt.Errorf(helpers.NotOnPremSupported)
 	}
 	params := network_address_groups.NewV1NetworkAddressGroupsGetParams().WithContext(f.ctx).WithTimeout(helpers.PIGetTimeOut)
 	resp, err := f.session.Power.NetworkAddressGroups.V1NetworkAddressGroupsGet(params, f.session.AuthInfo(f.cloudInstanceID))
@@ -64,7 +64,7 @@ func (f *IBMPINetworkAddressGroupClient) GetAll() (*models.NetworkAddressGroups,
 func (f *IBMPINetworkAddressGroupClient) Get(id string) (*models.NetworkAddressGroup, error) {
 	// Add check for on-prem location
 	if f.session.IsOnPrem() {
-		return nil, fmt.Errorf("operation not supported in satellite location.")
+		return nil, fmt.Errorf(helpers.NotOnPremSupported)
 	}
 	params := network_address_groups.NewV1NetworkAddressGroupsIDGetParams().WithContext(f.ctx).WithTimeout(helpers.PIGetTimeOut).WithNetworkAddressGroupID(id)
 	resp, err := f.session.Power.NetworkAddressGroups.V1NetworkAddressGroupsIDGet(params, f.session.AuthInfo(f.cloudInstanceID))
@@ -82,7 +82,7 @@ func (f *IBMPINetworkAddressGroupClient) Get(id string) (*models.NetworkAddressG
 func (f *IBMPINetworkAddressGroupClient) Update(id string, body *models.NetworkAddressGroupUpdate) (*models.NetworkAddressGroup, error) {
 	// Add check for on-prem location
 	if f.session.IsOnPrem() {
-		return nil, fmt.Errorf("operation not supported in satellite location.")
+		return nil, fmt.Errorf(helpers.NotOnPremSupported)
 	}
 	params := network_address_groups.NewV1NetworkAddressGroupsIDPutParams().WithContext(f.ctx).WithTimeout(helpers.PIUpdateTimeOut).WithNetworkAddressGroupID(id).WithBody(body)
 	resp, err := f.session.Power.NetworkAddressGroups.V1NetworkAddressGroupsIDPut(params, f.session.AuthInfo(f.cloudInstanceID))
@@ -99,7 +99,7 @@ func (f *IBMPINetworkAddressGroupClient) Update(id string, body *models.NetworkA
 func (f *IBMPINetworkAddressGroupClient) Delete(id string) error {
 	// Add check for on-prem location
 	if f.session.IsOnPrem() {
-		return fmt.Errorf("operation not supported in satellite location.")
+		return fmt.Errorf(helpers.NotOnPremSupported)
 	}
 	params := network_address_groups.NewV1NetworkAddressGroupsIDDeleteParams().WithContext(f.ctx).WithTimeout(helpers.PIDeleteTimeOut).WithNetworkAddressGroupID(id)
 	_, err := f.session.Power.NetworkAddressGroups.V1NetworkAddressGroupsIDDelete(params, f.session.AuthInfo(f.cloudInstanceID))
@@ -113,7 +113,7 @@ func (f *IBMPINetworkAddressGroupClient) Delete(id string) error {
 func (f *IBMPINetworkAddressGroupClient) AddMember(id string, body *models.NetworkAddressGroupAddMember) (*models.NetworkAddressGroupMember, error) {
 	// Add check for on-prem location
 	if f.session.IsOnPrem() {
-		return nil, fmt.Errorf("operation not supported in satellite location.")
+		return nil, fmt.Errorf(helpers.NotOnPremSupported)
 	}
 	params := network_address_groups.NewV1NetworkAddressGroupsMembersPostParams().WithContext(f.ctx).WithTimeout(helpers.PICreateTimeOut).WithNetworkAddressGroupID(id).WithBody(body)
 	resp, err := f.session.Power.NetworkAddressGroups.V1NetworkAddressGroupsMembersPost(params, f.session.AuthInfo(f.cloudInstanceID))
@@ -130,7 +130,7 @@ func (f *IBMPINetworkAddressGroupClient) AddMember(id string, body *models.Netwo
 func (f *IBMPINetworkAddressGroupClient) DeleteMember(id, memberId string) error {
 	// Add check for on-prem location
 	if f.session.IsOnPrem() {
-		return fmt.Errorf("operation not supported in satellite location.")
+		return fmt.Errorf(helpers.NotOnPremSupported)
 	}
 	params := network_address_groups.NewV1NetworkAddressGroupsMembersDeleteParams().WithContext(f.ctx).WithTimeout(helpers.PIDeleteTimeOut).WithNetworkAddressGroupID(id).WithNetworkAddressGroupMemberID(memberId)
 	_, err := f.session.Power.NetworkAddressGroups.V1NetworkAddressGroupsMembersDelete(params, f.session.AuthInfo(f.cloudInstanceID))

--- a/clients/instance/ibm-pi-network-peers.go
+++ b/clients/instance/ibm-pi-network-peers.go
@@ -25,7 +25,7 @@ func NewIBMPINetworkPeerClient(ctx context.Context, sess *ibmpisession.IBMPISess
 // Get network peers
 func (f *IBMPINetworkPeerClient) GetNetworkPeers() (*models.NetworkPeers, error) {
 	if !f.session.IsOnPrem() {
-		return nil, fmt.Errorf("not supported in off-prem location")
+		return nil, fmt.Errorf(helpers.NotOffPremSupported)
 	}
 	params := network_peers.NewV1NetworkPeersListParams().WithContext(f.ctx).
 		WithTimeout(helpers.PIGetTimeOut)

--- a/clients/instance/ibm-pi-network-security-group.go
+++ b/clients/instance/ibm-pi-network-security-group.go
@@ -26,7 +26,7 @@ func NewIBMIPINetworkSecurityGroupClient(ctx context.Context, sess *ibmpisession
 func (f *IBMPINetworkSecurityGroupClient) Get(id string) (*models.NetworkSecurityGroup, error) {
 	// Add check for on-prem location
 	if f.session.IsOnPrem() {
-		return nil, fmt.Errorf("operation not supported in satellite location.")
+		return nil, fmt.Errorf(helpers.NotOnPremSupported)
 	}
 	params := network_security_groups.NewV1NetworkSecurityGroupsIDGetParams().WithContext(f.ctx).WithTimeout(helpers.PIGetTimeOut).WithNetworkSecurityGroupID(id)
 	resp, err := f.session.Power.NetworkSecurityGroups.V1NetworkSecurityGroupsIDGet(params, f.session.AuthInfo(f.cloudInstanceID))
@@ -43,7 +43,7 @@ func (f *IBMPINetworkSecurityGroupClient) Get(id string) (*models.NetworkSecurit
 func (f *IBMPINetworkSecurityGroupClient) GetAll() (*models.NetworkSecurityGroups, error) {
 	// Add check for on-prem location
 	if f.session.IsOnPrem() {
-		return nil, fmt.Errorf("operation not supported in satellite location.")
+		return nil, fmt.Errorf(helpers.NotOnPremSupported)
 	}
 	params := network_security_groups.NewV1NetworkSecurityGroupsListParams().WithContext(f.ctx).WithTimeout(helpers.PIGetTimeOut)
 	resp, err := f.session.Power.NetworkSecurityGroups.V1NetworkSecurityGroupsList(params, f.session.AuthInfo(f.cloudInstanceID))
@@ -60,7 +60,7 @@ func (f *IBMPINetworkSecurityGroupClient) GetAll() (*models.NetworkSecurityGroup
 func (f *IBMPINetworkSecurityGroupClient) Create(body *models.NetworkSecurityGroupCreate) (*models.NetworkSecurityGroup, error) {
 	// Add check for on-prem location
 	if f.session.IsOnPrem() {
-		return nil, fmt.Errorf("operation not supported in satellite location.")
+		return nil, fmt.Errorf(helpers.NotOnPremSupported)
 	}
 	params := network_security_groups.NewV1NetworkSecurityGroupsPostParams().WithContext(f.ctx).WithTimeout(helpers.PICreateTimeOut).WithBody(body)
 	postok, postcreated, err := f.session.Power.NetworkSecurityGroups.V1NetworkSecurityGroupsPost(params, f.session.AuthInfo(f.cloudInstanceID))
@@ -80,7 +80,7 @@ func (f *IBMPINetworkSecurityGroupClient) Create(body *models.NetworkSecurityGro
 func (f *IBMPINetworkSecurityGroupClient) Update(id string, body *models.NetworkSecurityGroupUpdate) (*models.NetworkSecurityGroup, error) {
 	// Add check for on-prem location
 	if f.session.IsOnPrem() {
-		return nil, fmt.Errorf("operation not supported in satellite location.")
+		return nil, fmt.Errorf(helpers.NotOnPremSupported)
 	}
 	params := network_security_groups.NewV1NetworkSecurityGroupsIDPutParams().WithContext(f.ctx).WithTimeout(helpers.PIUpdateTimeOut).WithNetworkSecurityGroupID(id).WithBody(body)
 	resp, err := f.session.Power.NetworkSecurityGroups.V1NetworkSecurityGroupsIDPut(params, f.session.AuthInfo(f.cloudInstanceID))
@@ -97,7 +97,7 @@ func (f *IBMPINetworkSecurityGroupClient) Update(id string, body *models.Network
 func (f *IBMPINetworkSecurityGroupClient) Delete(id string) error {
 	// Add check for on-prem location
 	if f.session.IsOnPrem() {
-		return fmt.Errorf("operation not supported in satellite location.")
+		return fmt.Errorf(helpers.NotOnPremSupported)
 	}
 	params := network_security_groups.NewV1NetworkSecurityGroupsIDDeleteParams().WithContext(f.ctx).WithTimeout(helpers.PIDeleteTimeOut).WithNetworkSecurityGroupID(id)
 	_, err := f.session.Power.NetworkSecurityGroups.V1NetworkSecurityGroupsIDDelete(params, f.session.AuthInfo(f.cloudInstanceID))
@@ -111,7 +111,7 @@ func (f *IBMPINetworkSecurityGroupClient) Delete(id string) error {
 func (f *IBMPINetworkSecurityGroupClient) AddMember(id string, body *models.NetworkSecurityGroupAddMember) (*models.NetworkSecurityGroupMember, error) {
 	// Add check for on-prem location
 	if f.session.IsOnPrem() {
-		return nil, fmt.Errorf("operation not supported in satellite location.")
+		return nil, fmt.Errorf(helpers.NotOnPremSupported)
 	}
 	params := network_security_groups.NewV1NetworkSecurityGroupsMembersPostParams().WithContext(f.ctx).WithTimeout(helpers.PICreateTimeOut).WithNetworkSecurityGroupID(id).WithBody(body)
 	resp, err := f.session.Power.NetworkSecurityGroups.V1NetworkSecurityGroupsMembersPost(params, f.session.AuthInfo(f.cloudInstanceID))
@@ -128,7 +128,7 @@ func (f *IBMPINetworkSecurityGroupClient) AddMember(id string, body *models.Netw
 func (f *IBMPINetworkSecurityGroupClient) DeleteMember(id, memberId string) error {
 	// Add check for on-prem location
 	if f.session.IsOnPrem() {
-		return fmt.Errorf("operation not supported in satellite location.")
+		return fmt.Errorf(helpers.NotOnPremSupported)
 	}
 	params := network_security_groups.NewV1NetworkSecurityGroupsMembersDeleteParams().WithContext(f.ctx).WithTimeout(helpers.PIDeleteTimeOut).WithNetworkSecurityGroupID(id).WithNetworkSecurityGroupMemberID(memberId)
 	_, err := f.session.Power.NetworkSecurityGroups.V1NetworkSecurityGroupsMembersDelete(params, f.session.AuthInfo(f.cloudInstanceID))
@@ -142,7 +142,7 @@ func (f *IBMPINetworkSecurityGroupClient) DeleteMember(id, memberId string) erro
 func (f *IBMPINetworkSecurityGroupClient) AddRule(id string, body *models.NetworkSecurityGroupAddRule) (*models.NetworkSecurityGroupRule, error) {
 	// Add check for on-prem location
 	if f.session.IsOnPrem() {
-		return nil, fmt.Errorf("operation not supported in satellite location.")
+		return nil, fmt.Errorf(helpers.NotOnPremSupported)
 	}
 	params := network_security_groups.NewV1NetworkSecurityGroupsRulesPostParams().WithContext(f.ctx).WithTimeout(helpers.PICreateTimeOut).WithNetworkSecurityGroupID(id).WithBody(body)
 	resp, err := f.session.Power.NetworkSecurityGroups.V1NetworkSecurityGroupsRulesPost(params, f.session.AuthInfo(f.cloudInstanceID))
@@ -159,7 +159,7 @@ func (f *IBMPINetworkSecurityGroupClient) AddRule(id string, body *models.Networ
 func (f *IBMPINetworkSecurityGroupClient) DeleteRule(id, ruleId string) error {
 	// Add check for on-prem location
 	if f.session.IsOnPrem() {
-		return fmt.Errorf("operation not supported in satellite location.")
+		return fmt.Errorf(helpers.NotOnPremSupported)
 	}
 	params := network_security_groups.NewV1NetworkSecurityGroupsRulesDeleteParams().WithContext(f.ctx).WithTimeout(helpers.PIDeleteTimeOut).WithNetworkSecurityGroupID(id).WithNetworkSecurityGroupRuleID(ruleId)
 	_, err := f.session.Power.NetworkSecurityGroups.V1NetworkSecurityGroupsRulesDelete(params, f.session.AuthInfo(f.cloudInstanceID))
@@ -173,7 +173,7 @@ func (f *IBMPINetworkSecurityGroupClient) DeleteRule(id, ruleId string) error {
 func (f *IBMPINetworkSecurityGroupClient) Action(body *models.NetworkSecurityGroupsAction) error {
 	// Add check for on-prem location
 	if f.session.IsOnPrem() {
-		return fmt.Errorf("operation not supported in satellite location.")
+		return fmt.Errorf(helpers.NotOnPremSupported)
 	}
 	params := network_security_groups.NewV1NetworkSecurityGroupsActionPostParams().WithContext(f.ctx).WithTimeout(helpers.PICreateTimeOut).WithBody(body)
 	_, _, err := f.session.Power.NetworkSecurityGroups.V1NetworkSecurityGroupsActionPost(params, f.session.AuthInfo(f.cloudInstanceID))

--- a/clients/instance/ibm-pi-network.go
+++ b/clients/instance/ibm-pi-network.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/IBM-Cloud/power-go-client/errors"
 	"github.com/IBM-Cloud/power-go-client/helpers"
-
 	"github.com/IBM-Cloud/power-go-client/ibmpisession"
 	"github.com/IBM-Cloud/power-go-client/power/client/networks"
 	"github.com/IBM-Cloud/power-go-client/power/client/p_cloud_networks"

--- a/clients/instance/ibm-pi-placement-groups.go
+++ b/clients/instance/ibm-pi-placement-groups.go
@@ -5,10 +5,9 @@ import (
 	"fmt"
 
 	"github.com/IBM-Cloud/power-go-client/errors"
-	"github.com/IBM-Cloud/power-go-client/power/client/p_cloud_placement_groups"
-
 	"github.com/IBM-Cloud/power-go-client/helpers"
 	"github.com/IBM-Cloud/power-go-client/ibmpisession"
+	"github.com/IBM-Cloud/power-go-client/power/client/p_cloud_placement_groups"
 	"github.com/IBM-Cloud/power-go-client/power/models"
 )
 

--- a/clients/instance/ibm-pi-sap-instance.go
+++ b/clients/instance/ibm-pi-sap-instance.go
@@ -25,7 +25,7 @@ func NewIBMPISAPInstanceClient(ctx context.Context, sess *ibmpisession.IBMPISess
 // Create a SAP Instance
 func (f *IBMPISAPInstanceClient) Create(body *models.SAPCreate) (*models.PVMInstanceList, error) {
 	if f.session.IsOnPrem() {
-		return nil, fmt.Errorf("operation not supported in satellite location, check documentation")
+		return nil, fmt.Errorf(helpers.NotOnPremSupported)
 	}
 	params := p_cloud_s_a_p.NewPcloudSapPostParams().
 		WithContext(f.ctx).WithTimeout(helpers.PICreateTimeOut).
@@ -49,7 +49,7 @@ func (f *IBMPISAPInstanceClient) Create(body *models.SAPCreate) (*models.PVMInst
 // Get a SAP Profile
 func (f *IBMPISAPInstanceClient) GetSAPProfile(id string) (*models.SAPProfile, error) {
 	if f.session.IsOnPrem() {
-		return nil, fmt.Errorf("operation not supported in satellite location, check documentation")
+		return nil, fmt.Errorf(helpers.NotOnPremSupported)
 	}
 	params := p_cloud_s_a_p.NewPcloudSapGetParams().
 		WithContext(f.ctx).WithTimeout(helpers.PIGetTimeOut).
@@ -67,7 +67,7 @@ func (f *IBMPISAPInstanceClient) GetSAPProfile(id string) (*models.SAPProfile, e
 // Get All SAP Profiles
 func (f *IBMPISAPInstanceClient) GetAllSAPProfiles(cloudInstanceID string) (*models.SAPProfiles, error) {
 	if f.session.IsOnPrem() {
-		return nil, fmt.Errorf("operation not supported in satellite location, check documentation")
+		return nil, fmt.Errorf(helpers.NotOnPremSupported)
 	}
 	params := p_cloud_s_a_p.NewPcloudSapGetallParams().
 		WithContext(f.ctx).WithTimeout(helpers.PIGetTimeOut).

--- a/clients/instance/ibm-pi-shared-processor-pool.go
+++ b/clients/instance/ibm-pi-shared-processor-pool.go
@@ -5,10 +5,9 @@ import (
 	"fmt"
 
 	"github.com/IBM-Cloud/power-go-client/errors"
-	"github.com/IBM-Cloud/power-go-client/power/client/p_cloud_shared_processor_pools"
-
 	"github.com/IBM-Cloud/power-go-client/helpers"
 	"github.com/IBM-Cloud/power-go-client/ibmpisession"
+	"github.com/IBM-Cloud/power-go-client/power/client/p_cloud_shared_processor_pools"
 	"github.com/IBM-Cloud/power-go-client/power/models"
 )
 

--- a/clients/instance/ibm-pi-snapshot.go
+++ b/clients/instance/ibm-pi-snapshot.go
@@ -9,7 +9,6 @@ import (
 	"github.com/IBM-Cloud/power-go-client/power/client/p_cloud_p_vm_instances"
 	"github.com/IBM-Cloud/power-go-client/power/client/p_cloud_snapshots"
 	"github.com/IBM-Cloud/power-go-client/power/client/snapshots"
-
 	"github.com/IBM-Cloud/power-go-client/power/models"
 )
 

--- a/clients/instance/ibm-pi-spp-placement-groups.go
+++ b/clients/instance/ibm-pi-spp-placement-groups.go
@@ -5,10 +5,9 @@ import (
 	"fmt"
 
 	"github.com/IBM-Cloud/power-go-client/errors"
-	"github.com/IBM-Cloud/power-go-client/power/client/p_cloud_s_p_p_placement_groups"
-
 	"github.com/IBM-Cloud/power-go-client/helpers"
 	"github.com/IBM-Cloud/power-go-client/ibmpisession"
+	"github.com/IBM-Cloud/power-go-client/power/client/p_cloud_s_p_p_placement_groups"
 	"github.com/IBM-Cloud/power-go-client/power/models"
 )
 

--- a/clients/instance/ibm-pi-storage-tiers.go
+++ b/clients/instance/ibm-pi-storage-tiers.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/IBM-Cloud/power-go-client/errors"
 	"github.com/IBM-Cloud/power-go-client/helpers"
-
 	"github.com/IBM-Cloud/power-go-client/ibmpisession"
 	"github.com/IBM-Cloud/power-go-client/power/client/p_cloud_storage_tiers"
 	"github.com/IBM-Cloud/power-go-client/power/models"

--- a/clients/instance/ibm-pi-system-pools.go
+++ b/clients/instance/ibm-pi-system-pools.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/IBM-Cloud/power-go-client/errors"
 	"github.com/IBM-Cloud/power-go-client/helpers"
-
 	"github.com/IBM-Cloud/power-go-client/ibmpisession"
 	"github.com/IBM-Cloud/power-go-client/power/client/p_cloud_system_pools"
 	"github.com/IBM-Cloud/power-go-client/power/models"

--- a/clients/instance/ibm-pi-volume.go
+++ b/clients/instance/ibm-pi-volume.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 
 	"github.com/IBM-Cloud/power-go-client/errors"
-
 	"github.com/IBM-Cloud/power-go-client/helpers"
 	"github.com/IBM-Cloud/power-go-client/ibmpisession"
 	"github.com/IBM-Cloud/power-go-client/power/client/p_cloud_volumes"

--- a/clients/instance/ibm-pi-vpn-policy.go
+++ b/clients/instance/ibm-pi-vpn-policy.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/IBM-Cloud/power-go-client/errors"
 	"github.com/IBM-Cloud/power-go-client/helpers"
-
 	"github.com/IBM-Cloud/power-go-client/ibmpisession"
 	"github.com/IBM-Cloud/power-go-client/power/client/p_cloud_v_p_n_policies"
 	"github.com/IBM-Cloud/power-go-client/power/models"
@@ -28,7 +27,7 @@ func NewIBMPIVpnPolicyClient(ctx context.Context, sess *ibmpisession.IBMPISessio
 // Get an IKE Policy
 func (f *IBMPIVpnPolicyClient) GetIKEPolicy(id string) (*models.IKEPolicy, error) {
 	if f.session.IsOnPrem() {
-		return nil, fmt.Errorf("operation not supported in satellite location, check documentation")
+		return nil, fmt.Errorf(helpers.NotOnPremSupported)
 	}
 	params := p_cloud_v_p_n_policies.NewPcloudIkepoliciesGetParams().
 		WithContext(f.ctx).WithTimeout(helpers.PIGetTimeOut).
@@ -46,7 +45,7 @@ func (f *IBMPIVpnPolicyClient) GetIKEPolicy(id string) (*models.IKEPolicy, error
 // Create an IKE Policy
 func (f *IBMPIVpnPolicyClient) CreateIKEPolicy(body *models.IKEPolicyCreate) (*models.IKEPolicy, error) {
 	if f.session.IsOnPrem() {
-		return nil, fmt.Errorf("operation not supported in satellite location, check documentation")
+		return nil, fmt.Errorf(helpers.NotOnPremSupported)
 	}
 	params := p_cloud_v_p_n_policies.NewPcloudIkepoliciesPostParams().
 		WithContext(f.ctx).WithTimeout(helpers.PICreateTimeOut).
@@ -64,7 +63,7 @@ func (f *IBMPIVpnPolicyClient) CreateIKEPolicy(body *models.IKEPolicyCreate) (*m
 // Update an IKE Policy
 func (f *IBMPIVpnPolicyClient) UpdateIKEPolicy(id string, body *models.IKEPolicyUpdate) (*models.IKEPolicy, error) {
 	if f.session.IsOnPrem() {
-		return nil, fmt.Errorf("operation not supported in satellite location, check documentation")
+		return nil, fmt.Errorf(helpers.NotOnPremSupported)
 	}
 	params := p_cloud_v_p_n_policies.NewPcloudIkepoliciesPutParams().
 		WithContext(f.ctx).WithTimeout(helpers.PIUpdateTimeOut).
@@ -83,7 +82,7 @@ func (f *IBMPIVpnPolicyClient) UpdateIKEPolicy(id string, body *models.IKEPolicy
 // Get All IKE Policies
 func (f *IBMPIVpnPolicyClient) GetAllIKEPolicies() (*models.IKEPolicies, error) {
 	if f.session.IsOnPrem() {
-		return nil, fmt.Errorf("operation not supported in satellite location, check documentation")
+		return nil, fmt.Errorf(helpers.NotOnPremSupported)
 	}
 	params := p_cloud_v_p_n_policies.NewPcloudIkepoliciesGetallParams().
 		WithContext(f.ctx).WithTimeout(helpers.PIGetTimeOut).
@@ -101,7 +100,7 @@ func (f *IBMPIVpnPolicyClient) GetAllIKEPolicies() (*models.IKEPolicies, error) 
 // Delete an IKE Policy
 func (f *IBMPIVpnPolicyClient) DeleteIKEPolicy(id string) error {
 	if f.session.IsOnPrem() {
-		return fmt.Errorf("operation not supported in satellite location, check documentation")
+		return fmt.Errorf(helpers.NotOnPremSupported)
 	}
 	params := p_cloud_v_p_n_policies.NewPcloudIkepoliciesDeleteParams().
 		WithContext(f.ctx).WithTimeout(helpers.PIDeleteTimeOut).
@@ -117,7 +116,7 @@ func (f *IBMPIVpnPolicyClient) DeleteIKEPolicy(id string) error {
 // Get an IPSec Policy
 func (f *IBMPIVpnPolicyClient) GetIPSecPolicy(id string) (*models.IPSecPolicy, error) {
 	if f.session.IsOnPrem() {
-		return nil, fmt.Errorf("operation not supported in satellite location, check documentation")
+		return nil, fmt.Errorf(helpers.NotOnPremSupported)
 	}
 	params := p_cloud_v_p_n_policies.NewPcloudIpsecpoliciesGetParams().
 		WithContext(f.ctx).WithTimeout(helpers.PIGetTimeOut).
@@ -135,7 +134,7 @@ func (f *IBMPIVpnPolicyClient) GetIPSecPolicy(id string) (*models.IPSecPolicy, e
 // Create an IPSec Policy
 func (f *IBMPIVpnPolicyClient) CreateIPSecPolicy(body *models.IPSecPolicyCreate) (*models.IPSecPolicy, error) {
 	if f.session.IsOnPrem() {
-		return nil, fmt.Errorf("operation not supported in satellite location, check documentation")
+		return nil, fmt.Errorf(helpers.NotOnPremSupported)
 	}
 	params := p_cloud_v_p_n_policies.NewPcloudIpsecpoliciesPostParams().
 		WithContext(f.ctx).WithTimeout(helpers.PICreateTimeOut).
@@ -153,7 +152,7 @@ func (f *IBMPIVpnPolicyClient) CreateIPSecPolicy(body *models.IPSecPolicyCreate)
 // Update an IPSec Policy
 func (f *IBMPIVpnPolicyClient) UpdateIPSecPolicy(id string, body *models.IPSecPolicyUpdate) (*models.IPSecPolicy, error) {
 	if f.session.IsOnPrem() {
-		return nil, fmt.Errorf("operation not supported in satellite location, check documentation")
+		return nil, fmt.Errorf(helpers.NotOnPremSupported)
 	}
 	params := p_cloud_v_p_n_policies.NewPcloudIpsecpoliciesPutParams().
 		WithContext(f.ctx).WithTimeout(helpers.PIUpdateTimeOut).
@@ -172,7 +171,7 @@ func (f *IBMPIVpnPolicyClient) UpdateIPSecPolicy(id string, body *models.IPSecPo
 // Get All IPSec Policies
 func (f *IBMPIVpnPolicyClient) GetAllIPSecPolicies() (*models.IPSecPolicies, error) {
 	if f.session.IsOnPrem() {
-		return nil, fmt.Errorf("operation not supported in satellite location, check documentation")
+		return nil, fmt.Errorf(helpers.NotOnPremSupported)
 	}
 	params := p_cloud_v_p_n_policies.NewPcloudIpsecpoliciesGetallParams().
 		WithContext(f.ctx).WithTimeout(helpers.PIGetTimeOut).
@@ -190,7 +189,7 @@ func (f *IBMPIVpnPolicyClient) GetAllIPSecPolicies() (*models.IPSecPolicies, err
 // Delete an IPSec Policy
 func (f *IBMPIVpnPolicyClient) DeleteIPSecPolicy(id string) error {
 	if f.session.IsOnPrem() {
-		return fmt.Errorf("operation not supported in satellite location, check documentation")
+		return fmt.Errorf(helpers.NotOnPremSupported)
 	}
 	params := p_cloud_v_p_n_policies.NewPcloudIpsecpoliciesDeleteParams().
 		WithContext(f.ctx).WithTimeout(helpers.PIDeleteTimeOut).

--- a/clients/instance/ibm-pi-vpn.go
+++ b/clients/instance/ibm-pi-vpn.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/IBM-Cloud/power-go-client/errors"
 	"github.com/IBM-Cloud/power-go-client/helpers"
-
 	"github.com/IBM-Cloud/power-go-client/ibmpisession"
 	"github.com/IBM-Cloud/power-go-client/power/client/p_cloud_v_p_n_connections"
 	"github.com/IBM-Cloud/power-go-client/power/models"
@@ -27,7 +26,7 @@ func NewIBMPIVpnConnectionClient(ctx context.Context, sess *ibmpisession.IBMPISe
 // Get a VPN Connection
 func (f *IBMPIVpnConnectionClient) Get(id string) (*models.VPNConnection, error) {
 	if f.session.IsOnPrem() {
-		return nil, fmt.Errorf("operation not supported in satellite location, check documentation")
+		return nil, fmt.Errorf(helpers.NotOnPremSupported)
 	}
 	params := p_cloud_v_p_n_connections.NewPcloudVpnconnectionsGetParams().
 		WithContext(f.ctx).WithTimeout(helpers.PIGetTimeOut).
@@ -50,7 +49,7 @@ func (f *IBMPIVpnConnectionClient) Create(body *models.VPNConnectionCreate) (*mo
 // Update a VPN Connection
 func (f *IBMPIVpnConnectionClient) Update(id string, body *models.VPNConnectionUpdate) (*models.VPNConnection, error) {
 	if f.session.IsOnPrem() {
-		return nil, fmt.Errorf("operation not supported in satellite location, check documentation")
+		return nil, fmt.Errorf(helpers.NotOnPremSupported)
 	}
 	params := p_cloud_v_p_n_connections.NewPcloudVpnconnectionsPutParams().
 		WithContext(f.ctx).WithTimeout(helpers.PIUpdateTimeOut).
@@ -69,7 +68,7 @@ func (f *IBMPIVpnConnectionClient) Update(id string, body *models.VPNConnectionU
 // Get All VPN Connections
 func (f *IBMPIVpnConnectionClient) GetAll() (*models.VPNConnections, error) {
 	if f.session.IsOnPrem() {
-		return nil, fmt.Errorf("operation not supported in satellite location, check documentation")
+		return nil, fmt.Errorf(helpers.NotOnPremSupported)
 	}
 	params := p_cloud_v_p_n_connections.NewPcloudVpnconnectionsGetallParams().
 		WithContext(f.ctx).WithTimeout(helpers.PIGetTimeOut).
@@ -87,7 +86,7 @@ func (f *IBMPIVpnConnectionClient) GetAll() (*models.VPNConnections, error) {
 // Delete a VPN Connection
 func (f *IBMPIVpnConnectionClient) Delete(id string) (*models.JobReference, error) {
 	if f.session.IsOnPrem() {
-		return nil, fmt.Errorf("operation not supported in satellite location, check documentation")
+		return nil, fmt.Errorf(helpers.NotOnPremSupported)
 	}
 	params := p_cloud_v_p_n_connections.NewPcloudVpnconnectionsDeleteParams().
 		WithContext(f.ctx).WithTimeout(helpers.PIDeleteTimeOut).
@@ -105,7 +104,7 @@ func (f *IBMPIVpnConnectionClient) Delete(id string) (*models.JobReference, erro
 // Get a VPN Connection's Network
 func (f *IBMPIVpnConnectionClient) GetNetwork(id string) (*models.NetworkIDs, error) {
 	if f.session.IsOnPrem() {
-		return nil, fmt.Errorf("operation not supported in satellite location, check documentation")
+		return nil, fmt.Errorf(helpers.NotOnPremSupported)
 	}
 	params := p_cloud_v_p_n_connections.NewPcloudVpnconnectionsNetworksGetParams().
 		WithContext(f.ctx).WithTimeout(helpers.PIGetTimeOut).
@@ -123,7 +122,7 @@ func (f *IBMPIVpnConnectionClient) GetNetwork(id string) (*models.NetworkIDs, er
 // Attach a Network to a VPN Connection
 func (f *IBMPIVpnConnectionClient) AddNetwork(id, networkID string) (*models.JobReference, error) {
 	if f.session.IsOnPrem() {
-		return nil, fmt.Errorf("operation not supported in satellite location, check documentation")
+		return nil, fmt.Errorf(helpers.NotOnPremSupported)
 	}
 	params := p_cloud_v_p_n_connections.NewPcloudVpnconnectionsNetworksPutParams().
 		WithContext(f.ctx).WithTimeout(helpers.PIUpdateTimeOut).
@@ -142,7 +141,7 @@ func (f *IBMPIVpnConnectionClient) AddNetwork(id, networkID string) (*models.Job
 // Detach a Network from a VPN Connection
 func (f *IBMPIVpnConnectionClient) DeleteNetwork(id, networkID string) (*models.JobReference, error) {
 	if f.session.IsOnPrem() {
-		return nil, fmt.Errorf("operation not supported in satellite location, check documentation")
+		return nil, fmt.Errorf(helpers.NotOnPremSupported)
 	}
 	params := p_cloud_v_p_n_connections.NewPcloudVpnconnectionsNetworksDeleteParams().
 		WithContext(f.ctx).WithTimeout(helpers.PIDeleteTimeOut).
@@ -161,7 +160,7 @@ func (f *IBMPIVpnConnectionClient) DeleteNetwork(id, networkID string) (*models.
 // Get a VPN Connection's Subnet
 func (f *IBMPIVpnConnectionClient) GetSubnet(id string) (*models.PeerSubnets, error) {
 	if f.session.IsOnPrem() {
-		return nil, fmt.Errorf("operation not supported in satellite location, check documentation")
+		return nil, fmt.Errorf(helpers.NotOnPremSupported)
 	}
 	params := p_cloud_v_p_n_connections.NewPcloudVpnconnectionsPeersubnetsGetParams().
 		WithContext(f.ctx).WithTimeout(helpers.PIGetTimeOut).
@@ -179,7 +178,7 @@ func (f *IBMPIVpnConnectionClient) GetSubnet(id string) (*models.PeerSubnets, er
 // Attach a Subnet to a VPN Connection
 func (f *IBMPIVpnConnectionClient) AddSubnet(id, subnet string) (*models.PeerSubnets, error) {
 	if f.session.IsOnPrem() {
-		return nil, fmt.Errorf("operation not supported in satellite location, check documentation")
+		return nil, fmt.Errorf(helpers.NotOnPremSupported)
 	}
 	params := p_cloud_v_p_n_connections.NewPcloudVpnconnectionsPeersubnetsPutParams().
 		WithContext(f.ctx).WithTimeout(helpers.PIUpdateTimeOut).
@@ -198,7 +197,7 @@ func (f *IBMPIVpnConnectionClient) AddSubnet(id, subnet string) (*models.PeerSub
 // Detach a Subnet from a VPN Connection
 func (f *IBMPIVpnConnectionClient) DeleteSubnet(id, subnet string) (*models.PeerSubnets, error) {
 	if f.session.IsOnPrem() {
-		return nil, fmt.Errorf("operation not supported in satellite location, check documentation")
+		return nil, fmt.Errorf(helpers.NotOnPremSupported)
 	}
 	params := p_cloud_v_p_n_connections.NewPcloudVpnconnectionsPeersubnetsDeleteParams().
 		WithContext(f.ctx).WithTimeout(helpers.PIDeleteTimeOut).

--- a/clients/instance/ibm-pi-workspaces.go
+++ b/clients/instance/ibm-pi-workspaces.go
@@ -42,7 +42,7 @@ func NewIBMPIWorkspacesClient(ctx context.Context, sess *ibmpisession.IBMPISessi
 // Get a workspace
 func (f *IBMPIWorkspacesClient) Get(cloudInstanceID string) (*models.Workspace, error) {
 	if f.session.IsOnPrem() {
-		return nil, fmt.Errorf("operation not supported in satellite location, check documentation")
+		return nil, fmt.Errorf(helpers.NotOnPremSupported)
 	}
 	params := workspaces.NewV1WorkspacesGetParams().WithContext(f.ctx).WithTimeout(helpers.PIGetTimeOut).WithWorkspaceID(cloudInstanceID)
 	resp, err := f.session.Power.Workspaces.V1WorkspacesGet(params, f.session.AuthInfo(f.cloudInstanceID))
@@ -58,7 +58,7 @@ func (f *IBMPIWorkspacesClient) Get(cloudInstanceID string) (*models.Workspace, 
 // Get all workspaces
 func (f *IBMPIWorkspacesClient) GetAll() (*models.Workspaces, error) {
 	if f.session.IsOnPrem() {
-		return nil, fmt.Errorf("operation not supported in satellite location, check documentation")
+		return nil, fmt.Errorf(helpers.NotOnPremSupported)
 	}
 	params := workspaces.NewV1WorkspacesGetallParams().WithContext(f.ctx).WithTimeout(helpers.PIGetTimeOut)
 	resp, err := f.session.Power.Workspaces.V1WorkspacesGetall(params, f.session.AuthInfo(f.cloudInstanceID))

--- a/helpers/constants.go
+++ b/helpers/constants.go
@@ -245,4 +245,8 @@ const (
 
 	// Stratos region prefix
 	PIStratosRegionPrefix = "satloc"
+
+	// Standard "not supported" messages
+	NotOnPremSupported  = "operation not supported in on-prem location"
+	NotOffPremSupported = "operation not supported in off-prem location"
 )


### PR DESCRIPTION
I standardized the generic error message when encountering a location specific operation and put it in a constant.