### PR TITLE
Remove jumbo check from sdk

### DIFF
--- a/clients/instance/ibm-pi-network.go
+++ b/clients/instance/ibm-pi-network.go
@@ -56,10 +56,6 @@ func (f *IBMPINetworkClient) GetAll() (*models.Networks, error) {
 
 // Create a Network
 func (f *IBMPINetworkClient) Create(body *models.NetworkCreate) (*models.Network, error) {
-	// Check for satellite differences in this endpoint
-	if f.session.IsOnPrem() && body.Jumbo {
-		return nil, fmt.Errorf("jumbo parameter is not supported in on-prem location, use mtu instead")
-	}
 	params := p_cloud_networks.NewPcloudNetworksPostParams().
 		WithContext(f.ctx).WithTimeout(helpers.PICreateTimeOut).
 		WithCloudInstanceID(f.cloudInstanceID).WithBody(body)


### PR DESCRIPTION
Part of the change for removing access-config and deprecating peer-id, peer-type and source-id in the network data source/resources.