### PR TITLE
Deprecate Network Port methods and update examples, tests

### DIFF
--- a/clients/instance/ibm-pi-network.go
+++ b/clients/instance/ibm-pi-network.go
@@ -117,6 +117,8 @@ func (f *IBMPINetworkClient) Delete(id string) error {
 }
 
 // Get All Ports on a Network
+//
+// Deprecated: This method is deprecated. Use GetAllNetworkInterfaces instead.
 func (f *IBMPINetworkClient) GetAllPorts(id string) (*models.NetworkPorts, error) {
 	params := p_cloud_networks.NewPcloudNetworksPortsGetallParams().
 		WithContext(f.ctx).WithTimeout(helpers.PIGetTimeOut).
@@ -132,6 +134,8 @@ func (f *IBMPINetworkClient) GetAllPorts(id string) (*models.NetworkPorts, error
 }
 
 // Get a Port on a Network
+//
+// Deprecated: This method is deprecated. Use GetNetworkInterface instead.
 func (f *IBMPINetworkClient) GetPort(id string, networkPortID string) (*models.NetworkPort, error) {
 	params := p_cloud_networks.NewPcloudNetworksPortsGetParams().
 		WithContext(f.ctx).WithTimeout(helpers.PIGetTimeOut).
@@ -149,6 +153,8 @@ func (f *IBMPINetworkClient) GetPort(id string, networkPortID string) (*models.N
 }
 
 // Create a Port on a Network
+//
+// Deprecated: This method is deprecated. Use CreateNetworkInterface instead.
 func (f *IBMPINetworkClient) CreatePort(id string, body *models.NetworkPortCreate) (*models.NetworkPort, error) {
 	params := p_cloud_networks.NewPcloudNetworksPortsPostParams().
 		WithContext(f.ctx).WithTimeout(helpers.PICreateTimeOut).
@@ -165,6 +171,8 @@ func (f *IBMPINetworkClient) CreatePort(id string, body *models.NetworkPortCreat
 }
 
 // Delete a Port on a Network
+//
+// Deprecated: This method is deprecated. Use DeleteNetworkInterface instead.
 func (f *IBMPINetworkClient) DeletePort(id string, networkPortID string) error {
 	params := p_cloud_networks.NewPcloudNetworksPortsDeleteParams().
 		WithContext(f.ctx).WithTimeout(helpers.PIDeleteTimeOut).
@@ -178,6 +186,8 @@ func (f *IBMPINetworkClient) DeletePort(id string, networkPortID string) error {
 }
 
 // Update a Port on a Network
+//
+// Deprecated: This method is deprecated. Use UpdateNetworkInterface instead.
 func (f *IBMPINetworkClient) UpdatePort(id, networkPortID string, body *models.NetworkPortUpdate) (*models.NetworkPort, error) {
 	params := p_cloud_networks.NewPcloudNetworksPortsPutParams().
 		WithContext(f.ctx).WithTimeout(helpers.PIUpdateTimeOut).

--- a/clients/instance/ibm-pi-network_integration_test.go
+++ b/clients/instance/ibm-pi-network_integration_test.go
@@ -64,33 +64,33 @@ func TestNetwork(t *testing.T) {
 	require.Equal(t, createNetResp.Mtu, utl.NetworkMtu)
 	require.Equal(t, createNetResp.AccessConfig, utl.NetworkAccessConfig)
 
-	// CREATE Port
-	portBody := &models.NetworkPortCreate{
-		Description: "Network Port",
+	// CREATE Network Interface (replacing deprecated CreatePort)
+	netIntBody := &models.NetworkInterfaceCreate{
+		Name: "Network Interface",
 	}
-	createPortResp, err := networkClient.CreatePort(NetworkID, portBody)
+	createNetIntResp, err := networkClient.CreateNetworkInterface(NetworkID, netIntBody)
 	require.Nil(t, err)
-	portID := *createPortResp.PortID
-	utl.TestMessage("CREATE Network Port", portID, *createPortResp)
+	netIntID := *createNetIntResp.ID
+	utl.TestMessage("CREATE Network Interface", netIntID, *createNetIntResp)
 
-	// DELETE Port
+	// DELETE Network Interface (replacing deprecated DeletePort)
 	defer func() {
-		err = networkClient.DeletePort(NetworkID, portID)
+		err = networkClient.DeleteNetworkInterface(NetworkID, netIntID)
 		require.Nil(t, err)
-		utl.TestMessage("DELETE Network: "+NetworkID+" Port", portID, nil)
+		utl.TestMessage("DELETE Network: "+NetworkID+" Interface", netIntID, nil)
 	}()
 
-	// GET Port
-	getPortResp, err := networkClient.GetPort(NetworkID, portID)
+	// GET Network Interface (replacing deprecated GetPort)
+	getNetIntResp, err := networkClient.GetNetworkInterface(NetworkID, netIntID)
 	require.Nil(t, err)
-	utl.TestMessage("GET Network ", NetworkID+" Port "+portID, *getPortResp)
+	utl.TestMessage("GET Network ", NetworkID+" Interface "+netIntID, *getNetIntResp)
 	// verify variables match
-	require.Equal(t, *createPortResp.Description, "Network Port")
+	require.Equal(t, *createNetIntResp.Name, "Network Interface")
 
-	// GET ALL Ports
-	getAllPortResp, err := networkClient.GetAllPorts(NetworkID)
+	// GET ALL Network Interfaces (replacing deprecated GetAllPorts)
+	getAllNetIntResp, err := networkClient.GetAllNetworkInterfaces(NetworkID)
 	require.Nil(t, err)
-	utl.TestMessage("GET ALL Network Ports", NetworkID, *getAllPortResp)
+	utl.TestMessage("GET ALL Network Interfaces", NetworkID, *getAllNetIntResp)
 
 	// GET Public Networks
 	getPublicResp, err := networkClient.GetAllPublic()

--- a/examples/network/main.go
+++ b/examples/network/main.go
@@ -64,9 +64,6 @@ func main() {
 		log.Fatal(err)
 	}
 	powerClient := v.NewIBMPINetworkClient(context.Background(), session, piID)
-	if err != nil {
-		log.Fatal(err)
-	}
 	body := &models.NetworkCreate{
 		Type:         &netType,
 		Name:         name,
@@ -114,28 +111,29 @@ func main() {
 	}
 	log.Printf("***************[4]****************** %+v \n", *getpubResp)
 
-	portBody := &models.NetworkPortCreate{
-		Description: "Network Port",
+	// Using network interface methods instead of deprecated port methods
+	netIntBody := &models.NetworkInterfaceCreate{
+		Name: "Network Interface",
 	}
-	createPortResp, err := powerClient.CreatePort(networkID, portBody)
+	createNetIntResp, err := powerClient.CreateNetworkInterface(networkID, netIntBody)
 	if err != nil {
 		log.Fatal(err)
 	}
-	log.Printf("***************[5]****************** %+v \n", *createPortResp)
+	log.Printf("***************[5]****************** %+v \n", *createNetIntResp)
 
-	getPortResp, err := powerClient.GetPort(networkID, *createPortResp.PortID)
+	getNetIntResp, err := powerClient.GetNetworkInterface(networkID, *createNetIntResp.ID)
 	if err != nil {
 		log.Fatal(err)
 	}
-	log.Printf("***************[6]****************** %+v \n", *getPortResp)
+	log.Printf("***************[6]****************** %+v \n", *getNetIntResp)
 
-	getallPortResp, err := powerClient.GetAllPorts(networkID)
+	getallNetIntResp, err := powerClient.GetAllNetworkInterfaces(networkID)
 	if err != nil {
 		log.Fatal(err)
 	}
-	log.Printf("***************[7]****************** %+v \n", *getallPortResp)
+	log.Printf("***************[7]****************** %+v \n", *getallNetIntResp)
 
-	err = powerClient.DeletePort(networkID, *createPortResp.PortID)
+	err = powerClient.DeleteNetworkInterface(networkID, *createNetIntResp.ID)
 	if err != nil {
 		log.Fatal(err)
 	}


### PR DESCRIPTION
1. Identified deprecated methods in `p_cloud_networks_client.go`
2. Added deprecation comments in `ibm-pi-network.go`
3. Updated example code in `examples/network/main.go`
4. Updated integration test in `ibm-pi-network_integration_test.go`