### PR TITLE
Allow route commands for onprem workspaces

### DIFF
--- a/clients/instance/ibm-pi-routes.go
+++ b/clients/instance/ibm-pi-routes.go
@@ -24,9 +24,6 @@ func NewIBMPIRouteClient(ctx context.Context, sess *ibmpisession.IBMPISession, c
 
 // Get a routing rule
 func (f *IBMPIRouteClient) Get(id string) (*models.Route, error) {
-	if f.session.IsOnPrem() {
-		return nil, fmt.Errorf(helpers.NotOnPremSupported)
-	}
 	params := routes.NewV1RoutesGetParams().WithContext(f.ctx).WithTimeout(helpers.PIGetTimeOut).WithRouteID(id)
 	resp, err := f.session.Power.Routes.V1RoutesGet(params, f.session.AuthInfo(f.cloudInstanceID))
 	if err != nil {
@@ -40,9 +37,6 @@ func (f *IBMPIRouteClient) Get(id string) (*models.Route, error) {
 
 // Get all routes
 func (f *IBMPIRouteClient) GetAll() (*models.Routes, error) {
-	if f.session.IsOnPrem() {
-		return nil, fmt.Errorf(helpers.NotOnPremSupported)
-	}
 	params := routes.NewV1RoutesGetallParams().WithContext(f.ctx).WithTimeout(helpers.PIGetTimeOut)
 	resp, err := f.session.Power.Routes.V1RoutesGetall(params, f.session.AuthInfo(f.cloudInstanceID))
 	if err != nil {
@@ -56,9 +50,6 @@ func (f *IBMPIRouteClient) GetAll() (*models.Routes, error) {
 
 // Get route report
 func (f *IBMPIRouteClient) GetRouteReport() (*models.RouteReport, error) {
-	if f.session.IsOnPrem() {
-		return nil, fmt.Errorf(helpers.NotOnPremSupported)
-	}
 	params := routes.NewV1RoutesReportGetParams().WithContext(f.ctx).WithTimeout(helpers.PIGetTimeOut)
 	resp, err := f.session.Power.Routes.V1RoutesReportGet(params, f.session.AuthInfo(f.cloudInstanceID))
 	if err != nil {
@@ -72,9 +63,6 @@ func (f *IBMPIRouteClient) GetRouteReport() (*models.RouteReport, error) {
 
 // Create a routing rule
 func (f *IBMPIRouteClient) Create(body *models.RouteCreate) (*models.Route, error) {
-	if f.session.IsOnPrem() {
-		return nil, fmt.Errorf(helpers.NotOnPremSupported)
-	}
 	params := routes.NewV1RoutesPostParams().WithContext(f.ctx).WithTimeout(helpers.PICreateTimeOut).WithBody(body)
 	resp, err := f.session.Power.Routes.V1RoutesPost(params, f.session.AuthInfo(f.cloudInstanceID))
 	if err != nil {
@@ -88,9 +76,6 @@ func (f *IBMPIRouteClient) Create(body *models.RouteCreate) (*models.Route, erro
 
 // Update routing rule
 func (f *IBMPIRouteClient) Update(id string, body *models.RouteUpdate) (*models.Route, error) {
-	if f.session.IsOnPrem() {
-		return nil, fmt.Errorf(helpers.NotOnPremSupported)
-	}
 	params := routes.NewV1RoutesPutParams().WithContext(f.ctx).WithTimeout(helpers.PIUpdateTimeOut).WithRouteID(id).WithBody(body)
 	resp, err := f.session.Power.Routes.V1RoutesPut(params, f.session.AuthInfo(f.cloudInstanceID))
 	if err != nil {
@@ -104,9 +89,6 @@ func (f *IBMPIRouteClient) Update(id string, body *models.RouteUpdate) (*models.
 
 // Delete routing rule
 func (f *IBMPIRouteClient) Delete(id string) error {
-	if f.session.IsOnPrem() {
-		return fmt.Errorf(helpers.NotOnPremSupported)
-	}
 	params := routes.NewV1RoutesDeleteParams().WithContext(f.ctx).WithTimeout(helpers.PIDeleteTimeOut).WithRouteID(id)
 	_, err := f.session.Power.Routes.V1RoutesDelete(params, f.session.AuthInfo(f.cloudInstanceID))
 	if err != nil {


### PR DESCRIPTION
Noticed this while we were in our meeting today. We'll need to enable this for Q2 for networking to allow terraform to create routes on public workspaces.